### PR TITLE
Bugfix on MusicBrainz date and problem with executing arm_wrapper.sh

### DIFF
--- a/setup/51-automedia.rules
+++ b/setup/51-automedia.rules
@@ -4,6 +4,6 @@
 # ACTION=="change", SUBSYSTEM=="block", RUN+="/opt/arm/arm_wrapper.sh"
 # ACTION=="change", SUBSYSTEM=="block", RUN+="/opt/arm/arm/main.py -l '%E{ID_FS_LABEL}' -d '%E{DEVNAME}'"
 # ACTION=="change", SUBSYSTEM=="block", TAG+="systemd", KERNEL=="sr[0-9]*|vdisk*|xvd*", ENV{DEVTYPE}=="disk", RUN+="/bin/systemctl start arm@%k.service"
-ACTION=="change", SUBSYSTEM=="block", RUN+="/opt/arm/scripts/arm_wrapper.sh %k"
+ACTION=="change", SUBSYSTEM=="block", RUN+="source /opt/arm/scripts/arm_wrapper.sh %k"
 
 


### PR DESCRIPTION
I had an error when the result of `mb.get_releases_by_discid` did not contain a date of the release.

From the log: 
```
[08-03-2021 18:02:43] DEBUG ARM: music_brainz.music_brainz Infos: {'disc': {'id': 'OpyThxH2SDUOmxmxBjAJDHJ.S34-', 'sectors': '266620', 'offset-list': [183, 10673, 20435, 27245, 37743, 48988, 67955, 79733, 99078, 113975, 131563, 141908, 161920, 170425, 175135, 182013, 200258, 209075, 224188, 241508], 'offset-count': 20, 'release-list': [{'id': 'f04d91aa-5068-4cce-809e-ab34cb6017da', 'title': 'Die schöne Müllerin', 'status': 'Official', 'quality': 'normal', 'text-representation': {'language': 'deu', 'script': 'Latn'}, 'artist-credit': [{'name': 'Schubert', 'artist': {'id': 'f91e3a88-24ee-4563-8963-fab73d2765ed', 'type': 'Person', 'name': 'Franz Schubert', 'sort-name': 'Schubert, Franz', 'disambiguation': 'Austrian composer Franz Peter Schubert'}}, '; ', {'artist': {'id': '1bdc5968-3ca3-497f-b0c1-6de471b26b00', 'type': 'Person', 'name': 'Dietrich Fischer‐Dieskau', 'sort-name': 'Fischer‐Dieskau, Dietrich', 'disambiguation': 'baritone'}}, ', ', {'artist': {'id': '5978ca05-f0dd-42ef-b716-4ec0cbf659f8', 'type': 'Person', 'name': 'Gerald Moore', 'sort-name': 'Moore, Gerald', 'disambiguation': 'pianist'}}], 'barcode': '077774717328', 'asin': 'B000005GHL', 'cover-art-archive': {'artwork': 'true', 'count': '1', 'front': 'true', 'back': 'false'}, 'medium-list': [{'position': '1', 'format': 'CD', 'disc-list': [{'id': 'OpyThxH2SDUOmxmxBjAJDHJ.S34-', 'sectors': '266620', 'offset-list': [183, 10673, 20435, 27245, 37743, 48988, 67955, 79733, 99078, 113975, 131563, 141908, 161920, 170425, 175135, 182013, 200258, 209075, 224188, 241508], 'offset-count': 20}], 'disc-count': 1, 'track-list': [], 'track-count': 20}], 'medium-count': 1, 'artist-credit-phrase': 'Schubert; Dietrich Fischer‐Dieskau, Gerald Moore'}], 'release-count': 1}}
[08-03-2021 18:02:43] DEBUG ARM: music_brainz.music_brainz discid = OpyThxH2SDUOmxmxBjAJDHJ.S34-
[08-03-2021 18:02:43] ERROR ARM: main.<module> A fatal error has occurred and ARM is exiting.  See traceback below for details.
Traceback (most recent call last):
  File "/opt/arm/arm/ripper/main.py", line 524, in <module>
    main(logfile, job)
  File "/opt/arm/arm/ripper/main.py", line 123, in main
    identify.identify(job, logfile)
  File "/opt/arm/arm/ripper/identify.py", line 40, in identify
    job.label = music_brainz.main(job)
  File "/opt/arm/arm/ripper/music_brainz.py", line 23, in main
    return music_brainz(discid, disc)
  File "/opt/arm/arm/ripper/music_brainz.py", line 56, in music_brainz
    new_year = str(infos['disc']['release-list'][0]['date'])
KeyError: 'date'
```

A second problem arose when `scripts/arm_wrapper.sh` was not executable. (Not sure if this was the only problem at that time :-( ). Instead of requiring the user to chmod the file I decided to just `source` it in the udev-rule.

(And a bit of code simplification in the DRY sense.)