### PR TITLE
Bugfix jobconfig

### DIFF
--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -26,7 +26,7 @@ def notify(job, title, body):
     """
     # Pushbullet
     # pbul://{accesstoken}
-    if job.config.PB_KEY != "":
+    if getattr(job.config, "PB_KEY", ""):
         try:
             # Create an Apprise instance
             apobj = apprise.Apprise()
@@ -42,7 +42,7 @@ def notify(job, title, body):
             logging.error("Failed sending Pushbullet apprise notification.  Continuing processing...")
     # IFTTT
     # ifttt://{WebhookID}@{Event}/
-    if job.config.IFTTT_KEY != "":
+    if getattr(job.config, "IFTTT_KEY", ""):
         try:
             # Create an Apprise instance
             apobj = apprise.Apprise()
@@ -58,7 +58,7 @@ def notify(job, title, body):
         except:  # noqa: E722
             logging.error("Failed sending IFTTT apprise notification.  Continuing processing...")
     # PUSHOVER
-    if job.config.PO_USER_KEY != "":
+    if getattr(job.config, "PO_USER_KEY", ""):
         try:
             # Create an Apprise instance
             apobj = apprise.Apprise()
@@ -72,7 +72,7 @@ def notify(job, title, body):
             )
         except:  # noqa: E722
             logging.error("Failed sending PUSHOVER apprise notification.  continuing  processing...")
-    if job.config.APPRISE != "":
+    if getattr(job.config, "APPRISE", ""):
         try:
             apprise_notify(job.config.APPRISE, title, body)
             logging.debug("apprise-config: " + str(job.config.APPRISE))


### PR DESCRIPTION
I had an error where job.config had no attribute 'APPRISE'. Not sure where this came from, so I'm equally not sure, if this fix is really necessary, but it is more defensive programming.

```
[09-03-2021 18:55:32] ERROR ARM: main.<module> A fatal error has occurred and ARM is exiting.  See traceback below for details.
Traceback (most recent call last):
  File "/opt/arm/arm/ripper/main.py", line 525, in <module>
    main(logfile, job)
  File "/opt/arm/arm/ripper/main.py", line 144, in main
    utils.notify(job, "ARM notification", f"Found music CD: {job.label}. Ripping all tracks")
  File "/opt/arm/arm/ripper/utils.py", line 75, in notify
    if job.config.APPRISE != "":
AttributeError: 'Config' object has no attribute 'APPRISE'
```