### PR TITLE
Fix bug with incomplete job.config

### DIFF
--- a/arm/models/models.py
+++ b/arm/models/models.py
@@ -3,7 +3,7 @@ import pyudev
 import psutil
 import logging
 from arm.ui import db
-from arm.config.config import cfg  # noqa: E402
+from arm.config.config import cfg
 from flask_login import LoginManager, current_user, login_user, UserMixin  # noqa: F401
 from prettytable import PrettyTable
 

--- a/arm/ripper/handbrake.py
+++ b/arm/ripper/handbrake.py
@@ -16,6 +16,7 @@ from arm.ripper import utils
 # from arm.config.config import cfg
 from arm.models.models import Track  # noqa: F401
 from arm.ui import app, db  # noqa E402
+from arm.config.config import cfg
 
 
 def handbrake_mainfeature(srcpath, basepath, logfile, job):
@@ -36,12 +37,12 @@ def handbrake_mainfeature(srcpath, basepath, logfile, job):
     # db.session.commit()
     utils.database_updater({'status': "waiting_transcode"}, job)
     # TODO: send a notification that jobs are waiting ?
-    utils.sleep_check_process("HandBrakeCLI", int(job.config.MAX_CONCURRENT_TRANSCODES))
+    utils.sleep_check_process("HandBrakeCLI", int(cfg["MAX_CONCURRENT_TRANSCODES"]))
     logging.debug("Setting job status to 'transcoding'")
     # job.status = "transcoding"
     # db.session.commit()
     utils.database_updater({'status': "transcoding"}, job)
-    filename = os.path.join(basepath, job.title + "." + job.config.DEST_EXT)
+    filename = os.path.join(basepath, job.title + "." + cfg["DEST_EXT"])
     filepathname = os.path.join(basepath, filename)
     logging.info("Ripping title Mainfeature to " + shlex.quote(filepathname))
 
@@ -59,14 +60,14 @@ def handbrake_mainfeature(srcpath, basepath, logfile, job):
     db.session.commit()
 
     if job.disctype == "dvd":
-        hb_args = job.config.HB_ARGS_DVD
-        hb_preset = job.config.HB_PRESET_DVD
+        hb_args = cfg["HB_ARGS_DVD"]
+        hb_preset = cfg["HB_PRESET_DVD"]
     elif job.disctype == "bluray":
-        hb_args = job.config.HB_ARGS_BD
-        hb_preset = job.config.HB_PRESET_BD
+        hb_args = cfg["HB_ARGS_BD"]
+        hb_preset = cfg["HB_PRESET_BD"]
 
     cmd = 'nice {0} -i {1} -o {2} --main-feature --preset "{3}" {4} >> {5} 2>&1'.format(
-        job.config.HANDBRAKE_CLI,
+        cfg["HANDBRAKE_CLI"],
         shlex.quote(srcpath),
         shlex.quote(filepathname),
         hb_preset,
@@ -113,17 +114,17 @@ def handbrake_all(srcpath, basepath, logfile, job):
     # Wait until there is a spot to transcode
     job.status = "waiting_transcode"
     db.session.commit()
-    utils.sleep_check_process("HandBrakeCLI", int(job.config.MAX_CONCURRENT_TRANSCODES))
+    utils.sleep_check_process("HandBrakeCLI", int(cfg["MAX_CONCURRENT_TRANSCODES"]))
     job.status = "transcoding"
     db.session.commit()
     logging.info("Starting BluRay/DVD transcoding - All titles")
 
     if job.disctype == "dvd":
-        hb_args = job.config.HB_ARGS_DVD
-        hb_preset = job.config.HB_PRESET_DVD
+        hb_args = cfg["HB_ARGS_DVD"]
+        hb_preset = cfg["HB_PRESET_DVD"]
     elif job.disctype == "bluray":
-        hb_args = job.config.HB_ARGS_BD
-        hb_preset = job.config.HB_PRESET_BD
+        hb_args = cfg["HB_ARGS_BD"]
+        hb_preset = cfg["HB_PRESET_BD"]
 
     get_track_info(srcpath, job)
 
@@ -131,23 +132,23 @@ def handbrake_all(srcpath, basepath, logfile, job):
 
     for track in job.tracks:
 
-        if track.length < int(job.config.MINLENGTH):
+        if track.length < int(cfg["MINLENGTH"]):
             # too short
             logging.info("Track #" + str(track.track_number) + " of " + str(job.no_of_titles) + ". Length (" + str(
                 track.length) +
-                         ") is less than minimum length (" + job.config.MINLENGTH + ").  Skipping")
-        elif track.length > int(job.config.MAXLENGTH):
+                         ") is less than minimum length (" + cfg["MINLENGTH"] + ").  Skipping")
+        elif track.length > int(cfg["MAXLENGTH"]):
             # too long
             logging.info("Track #" + str(track.track_number) + " of " + str(job.no_of_titles) + ". Length (" + str(
                 track.length) +
-                         ") is greater than maximum length (" + job.config.MAXLENGTH + ").  Skipping")
+                         ") is greater than maximum length (" + cfg["MAXLENGTH"] + ").  Skipping")
         else:
             # just right
             logging.info(
                 "Processing track #" + str(track.track_number) + " of " + str(job.no_of_titles) + ". Length is " + str(
                     track.length) + " seconds.")
 
-            filename = "title_" + str.zfill(str(track.track_number), 2) + "." + job.config.DEST_EXT
+            filename = "title_" + str.zfill(str(track.track_number), 2) + "." + cfg["DEST_EXT"]
             filepathname = os.path.join(basepath, filename)
 
             logging.info("Transcoding title " + str(track.track_number) + " to " + shlex.quote(filepathname))
@@ -156,7 +157,7 @@ def handbrake_all(srcpath, basepath, logfile, job):
             db.session.commit()
 
             cmd = 'nice {0} -i {1} -o {2} --preset "{3}" -t {4} {5}>> {6} 2>&1'.format(
-                job.config.HANDBRAKE_CLI,
+                cfg["HANDBRAKE_CLI"],
                 shlex.quote(srcpath),
                 shlex.quote(filepathname),
                 hb_preset,
@@ -203,27 +204,27 @@ def handbrake_mkv(srcpath, basepath, logfile, job):
     # Added to limit number of transcodes
     job.status = "waiting_transcode"
     db.session.commit()
-    utils.sleep_check_process("HandBrakeCLI", int(job.config.MAX_CONCURRENT_TRANSCODES))
+    utils.sleep_check_process("HandBrakeCLI", int(cfg["MAX_CONCURRENT_TRANSCODES"]))
     job.status = "transcoding"
     db.session.commit()
     if job.disctype == "dvd":
-        hb_args = job.config.HB_ARGS_DVD
-        hb_preset = job.config.HB_PRESET_DVD
+        hb_args = cfg["HB_ARGS_DVD"]
+        hb_preset = cfg["HB_PRESET_DVD"]
     elif job.disctype == "bluray":
-        hb_args = job.config.HB_ARGS_BD
-        hb_preset = job.config.HB_PRESET_BD
+        hb_args = cfg["HB_ARGS_BD"]
+        hb_preset = cfg["HB_PRESET_BD"]
 
     # This will fail if the directory raw gets deleted
     for f in os.listdir(srcpath):
         srcpathname = os.path.join(srcpath, f)
         destfile = os.path.splitext(f)[0]
-        filename = os.path.join(basepath, destfile + "." + job.config.DEST_EXT)
+        filename = os.path.join(basepath, destfile + "." + cfg["DEST_EXT"])
         filepathname = os.path.join(basepath, filename)
 
         logging.info("Transcoding file " + shlex.quote(f) + " to " + shlex.quote(filepathname))
 
         cmd = 'nice {0} -i {1} -o {2} --preset "{3}" {4}>> {5} 2>&1'.format(
-            job.config.HANDBRAKE_CLI,
+            cfg["HANDBRAKE_CLI"],
             shlex.quote(srcpathname),
             shlex.quote(filepathname),
             hb_preset,
@@ -260,7 +261,7 @@ def get_track_info(srcpath, job):
     logging.info("Using HandBrake to get information on all the tracks on the disc.  This will take a few minutes...")
 
     cmd = '{0} -i {1} -t 0 --scan'.format(
-        job.config.HANDBRAKE_CLI,
+        cfg["HANDBRAKE_CLI"],
         shlex.quote(srcpath)
     )
 

--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -16,9 +16,8 @@ import requests
 from arm.ripper import music_brainz
 from arm.ripper import utils
 from arm.ui import db
+from arm.config.config import cfg
 
-
-# from arm.config.config import cfg
 
 # flake8: noqa: W605
 
@@ -61,7 +60,7 @@ def identify(job, logfile):
 
         logging.info("Disc identified as video")
 
-        if job.config.GET_VIDEO_TITLE:
+        if cfg["GET_VIDEO_TITLE"]:
             # get crc_id (dvd only), title, year
             if job.disctype == "dvd":
                 res = identify_dvd(job)
@@ -69,7 +68,6 @@ def identify(job, logfile):
                 res = identify_bluray(job)
             # Need to check if year is "0000"  or ""
             if res and job.year != "0000":
-                from arm.config.config import cfg
                 if cfg['METADATA_PROVIDER'].lower() == "tmdb":
                     tmdb_get_media_type(job)
                 elif cfg['METADATA_PROVIDER'].lower() == "omdb":
@@ -201,14 +199,13 @@ def identify_dvd(job):
     logging.debug("dvd_title SKU$= " + str(dvd_title))
 
     # try to contact omdb/tmdb
-    from arm.config.config import cfg
     if cfg['METADATA_PROVIDER'].lower() == "tmdb":
         logging.debug("using tmdb")
         tmdb_api_key = cfg['TMDB_API_KEY']
         dvd_info_xml = call_tmdb_service(job, tmdb_api_key, dvd_title, year)
     elif cfg['METADATA_PROVIDER'].lower() == "omdb":
         logging.debug("using omdb")
-        dvd_info_xml = callwebservice(job, job.config.OMDB_API_KEY, dvd_title, year)
+        dvd_info_xml = callwebservice(job, cfg["OMDB_API_KEY"], dvd_title, year)
     else:
         raise InputError("Error with metadata provider - Not supported")
     logging.debug("DVD_INFO_XML: " + str(dvd_info_xml))
@@ -251,8 +248,7 @@ def get_video_details(job):
         year = str(job.year)
         year = re.sub("[^0-9]", "", year)
 
-    omdb_api_key = job.config.OMDB_API_KEY
-    from arm.config.config import cfg
+    omdb_api_key = cfg["OMDB_API_KEY"]
     tmdb_api_key = cfg['TMDB_API_KEY']
     if cfg['METADATA_PROVIDER'].lower() == "tmdb":
         def call_web_service(j, api_key, dvd_title, y, tmdb_api=tmdb_api_key):
@@ -317,14 +313,14 @@ def get_video_details(job):
 def callwebservice(job, omdb_api_key, dvd_title, year=""):
     """ Queries OMDbapi.org for title information and parses type, imdb, and poster info
     """
-    if job.config.VIDEOTYPE == "auto":
+    if cfg["VIDEOTYPE"] == "auto":
         strurl = f"http://www.omdbapi.com/?t={dvd_title}&y={year}&plot=short&r=json&apikey={omdb_api_key}"
         logging.debug(f"http://www.omdbapi.com/?t={dvd_title}&y={year}&plot=short&r=json&apikey=key_hidden")
     else:
-        strurl = f"http://www.omdbapi.com/?t={dvd_title}&y={year}&type={job.config.VIDEOTYPE}" \
+        strurl = f"http://www.omdbapi.com/?t={dvd_title}&y={year}&type={cfg['VIDEOTYPE']}" \
                  f"&plot=short&r=json&apikey={omdb_api_key}"
         logging.debug(
-            f"http://www.omdbapi.com/?t={dvd_title}&y={year}&type={job.config.VIDEOTYPE}"
+            f"http://www.omdbapi.com/?t={dvd_title}&y={year}&type={cfg['VIDEOTYPE']}"
             f"&plot=short&r=json&apikey=key_hidden")
 
     logging.debug("***Calling webservice with Title: " + str(dvd_title) + " and Year: " + str(year))
@@ -520,7 +516,6 @@ def tmdb_get_media_type(job):
         year = str(job.year)
         year = re.sub("[^0-9]", "", year)
 
-    from arm.config.config import cfg
     tmdb_api_key = cfg['TMDB_API_KEY']
 
     logging.debug("Title: " + title + " | Year: " + year)

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -64,7 +64,7 @@ def log_arm_params(job):
                 "MAX_CONCURRENT_TRANSCODES"):
         logging.info(key.lower() +
                      ": " +
-                     str(getattr(job.config, key, '<not given>')))
+                     str(cfg.get(key, '<not given>')))
     logging.info("**** End of config parameters ****")
 
 
@@ -130,9 +130,9 @@ def main(logfile, job):
     if job.disctype in ["dvd", "bluray"]:
         #  Send the notifications
         utils.notify(job, "ARM notification",
-                     f"Found disc: {job.title}. Disc type is {job.disctype}. Main Feature is {job.config.MAINFEATURE}"
+                     f"Found disc: {job.title}. Disc type is {job.disctype}. Main Feature is {cfg['MAINFEATURE']}"
                      f".  Edit entry here: http://" + str(check_ip()) + ":"
-                     f"{job.config.WEBSERVER_PORT}/jobdetail?job_id={job.job_id}")
+                     f"{cfg['WEBSERVER_PORT']}/jobdetail?job_id={job.job_id}")
     elif job.disctype == "music":
         utils.notify(job, "ARM notification", f"Found music CD: {job.label}. Ripping all tracks")
     elif job.disctype == "data":
@@ -141,26 +141,14 @@ def main(logfile, job):
         utils.notify(job, "ARM Notification", "Could not identify disc.  Exiting.")
         sys.exit()
 
-    #  If we have have waiting for user input enabled
-    """if job.config.MANUAL_WAIT:
-        logging.info("Waiting " + str(job.config.MANUAL_WAIT_TIME) + " seconds for manual override.")
-        job.status = "waiting"
-        db.session.commit()
-        time.sleep(job.config.MANUAL_WAIT_TIME)
-        db.session.refresh(job)
-        db.session.refresh(config)
-        job.status = "active"
-        db.session.commit()
-    """
-
     # TODO: Update function that will look for the best match with most data
     #  If we have have waiting for user input enabled
-    if job.config.MANUAL_WAIT:
-        logging.info(f"Waiting {job.config.MANUAL_WAIT_TIME} seconds for manual override.")
+    if cfg["MANUAL_WAIT"]:
+        logging.info(f"Waiting {cfg['MANUAL_WAIT_TIME']} seconds for manual override.")
         job.status = "waiting"
         db.session.commit()
         sleep_time = 0
-        while sleep_time < job.config.MANUAL_WAIT_TIME:
+        while sleep_time < cfg["MANUAL_WAIT_TIME"]:
             time.sleep(5)
             sleep_time += 5
             db.session.refresh(job)
@@ -182,7 +170,7 @@ def main(logfile, job):
     log_arm_params(job)
     check_fstab()
 
-    if job.config.HASHEDKEYS:
+    if cfg["HASHEDKEYS"]:
         logging.info("Getting MakeMKV hashed keys for UHD rips")
         grabkeys()
 
@@ -192,28 +180,28 @@ def main(logfile, job):
         #  If we have a nice title/confirmed name use the MEDIA_DIR and not the ARM unidentified folder
         if job.hasnicetitle:
             if job.year != "0000" or job.year != "":
-                hboutpath = os.path.join(job.config.MEDIA_DIR, str(job.title) + " (" + str(job.year) + ")")
+                hboutpath = os.path.join(cfg["MEDIA_DIR"], str(job.title) + " (" + str(job.year) + ")")
             else:
-                hboutpath = os.path.join(job.config.MEDIA_DIR, str(job.title))
+                hboutpath = os.path.join(cfg["MEDIA_DIR"], str(job.title))
         else:
-            hboutpath = os.path.join(job.config.ARMPATH, str(job.title))
+            hboutpath = os.path.join(cfg["ARMPATH"], str(job.title))
 
         #  The dvd directory already exists - Lets make a new one using random numbers
         if (utils.make_dir(hboutpath)) is False:
             logging.info("Directory exist.")
             #  Only begin ripping if we are allowed to make duplicates
             # Or the successful rip of the disc is not found in our database
-            if job.config.ALLOW_DUPLICATES or not have_dupes:
+            if cfg["ALLOW_DUPLICATES"] or not have_dupes:
                 ts = round(time.time() * 100)
                 #  if we have a nice title, set the folder to MEDIA_DIR and not the unidentified ARMPATH
                 if job.hasnicetitle:
                     #  Dont use the year if its  0000
                     if job.year != "0000" or job.year != "":
-                        hboutpath = os.path.join(job.config.MEDIA_DIR, f"{job.title} ({job.year}) {ts}")
+                        hboutpath = os.path.join(cfg["MEDIA_DIR"], f"{job.title} ({job.year}) {ts}")
                     else:
-                        hboutpath = os.path.join(job.config.MEDIA_DIR, f"{job.title} {ts}")
+                        hboutpath = os.path.join(cfg["MEDIA_DIR"], f"{job.title} {ts}")
                 else:
-                    hboutpath = os.path.join(job.config.ARMPATH, str(job.title) + "_" + str(ts))
+                    hboutpath = os.path.join(cfg["ARMPATH"], str(job.title) + "_" + str(ts))
 
                 #  We failed to make a random directory, most likely a permission issue
                 if (utils.make_dir(hboutpath)) is False:
@@ -238,7 +226,7 @@ def main(logfile, job):
 
         #  entry point for bluray or dvd with MAINFEATURE off and RIPMETHOD mkv
         hbinpath = str(job.devpath)
-        if job.disctype == "bluray" or (not job.config.MAINFEATURE and job.config.RIPMETHOD == "mkv"):
+        if job.disctype == "bluray" or (not cfg["MAINFEATURE"] and cfg["RIPMETHOD"] == "mkv"):
             # send to makemkv for ripping
             # run MakeMKV and get path to output
             job.status = "ripping"
@@ -253,14 +241,14 @@ def main(logfile, job):
                 job.status = "fail"
                 db.session.commit()
                 sys.exit()
-            if job.config.NOTIFY_RIP:
+            if cfg["NOTIFY_RIP"]:
                 # Fixed bug line below
                 utils.notify(job, "ARM notification", str(job.title) + " rip complete.  Starting transcode. ")
             # point HB to the path MakeMKV ripped to
             hbinpath = mkvoutpath
 
             # Entry point for not transcoding
-            if job.config.SKIP_TRANSCODE and job.config.RIPMETHOD == "mkv":
+            if cfg["SKIP_TRANSCODE"] and cfg["RIPMETHOD"] == "mkv":
                 logging.info("SKIP_TRANSCODE is true.  Moving raw mkv files.")
                 logging.info("NOTE: Identified main feature may not be actual main feature")
                 files = os.listdir(mkvoutpath)
@@ -296,13 +284,13 @@ def main(logfile, job):
                                 utils.move_files(hbinpath, f, job, True)
                             else:
                                 # other extras
-                                if not str(job.config.EXTRAS_SUB).lower() == "none":
+                                if not str(cfg["EXTRAS_SUB"]).lower() == "none":
                                     # Incorporating Rajlaud's fix #349
                                     utils.move_files(hbinpath, f, job, False)
                                 else:
                                     logging.info("Not moving extra: " + f)
                     # Change final path (used to set permissions)
-                    final_directory = os.path.join(job.config.MEDIA_DIR, str(job.title) + " (" + str(job.year) + ")")
+                    final_directory = os.path.join(cfg["MEDIA_DIR"], str(job.title) + " (" + str(job.year) + ")")
                     # Clean up
                     #  TODO: fix this so it doesnt remove everything
                     logging.debug("Attempting to remove extra folder in ARMPATH: " + hboutpath)
@@ -322,11 +310,11 @@ def main(logfile, job):
                         logging.debug("Moving file: " + mkvoutfile + " to: " + mkvoutpath + f)
                         shutil.move(mkvoutfile, hboutpath)
                 # remove raw files, if specified in config
-                if job.config.DELRAWFILES:
+                if cfg["DELRAWFILES"]:
                     logging.info("Removing raw files")
                     shutil.rmtree(mkvoutpath)
                 # set file to default permissions '777'
-                if job.config.SET_MEDIA_PERMISSIONS:
+                if cfg["SET_MEDIA_PERMISSIONS"]:
                     perm_result = utils.set_permissions(job, final_directory)
                     logging.info("Permissions set successfully: " + str(perm_result))
                 utils.notify(job, "ARM notification", str(job.title) + " processing complete. ")
@@ -342,11 +330,11 @@ def main(logfile, job):
 
         job.status = "transcoding"
         db.session.commit()
-        if job.disctype == "bluray" and job.config.RIPMETHOD == "mkv":
+        if job.disctype == "bluray" and cfg["RIPMETHOD"] == "mkv":
             handbrake.handbrake_mkv(hbinpath, hboutpath, logfile, job)
-        elif job.disctype == "dvd" and (not job.config.MAINFEATURE and job.config.RIPMETHOD == "mkv"):
+        elif job.disctype == "dvd" and (not cfg["MAINFEATURE"] and cfg["RIPMETHOD"] == "mkv"):
             handbrake.handbrake_mkv(hbinpath, hboutpath, logfile, job)
-        elif job.video_type == "movie" and job.config.MAINFEATURE and job.hasnicetitle:
+        elif job.video_type == "movie" and cfg["MAINFEATURE"] and job.hasnicetitle:
             handbrake.handbrake_mainfeature(hbinpath, hboutpath, logfile, job)
             job.eject()
         else:
@@ -383,7 +371,7 @@ def main(logfile, job):
 
         #  Test for dvd fail permissions
         final_directory = p
-        if job.config.SET_MEDIA_PERMISSIONS:
+        if cfg["SET_MEDIA_PERMISSIONS"]:
             perm_result = utils.set_permissions(job, final_directory)
             logging.info("Permissions set successfully: " + str(perm_result))
 
@@ -411,7 +399,7 @@ def main(logfile, job):
 
         # Clean up bluray backup
         # if job.disctype == "bluray" and cfg["DELRAWFILES"]:
-        if job.config.DELRAWFILES:
+        if cfg["DELRAWFILES"]:
             try:
                 shutil.rmtree(mkvoutpath)
             except UnboundLocalError:
@@ -422,13 +410,13 @@ def main(logfile, job):
         # report errors if any
         if job.errors:
             errlist = ', '.join(job.errors)
-            if job.config.NOTIFY_TRANSCODE:
+            if cfg["NOTIFY_TRANSCODE"]:
                 utils.notify(job, "ARM notification",
                              str(job.title) + " processing completed with errors. Title(s) " + str(
                                  errlist) + " failed to complete. ")
             logging.info("Transcoding completed with errors.  Title(s) " + str(errlist) + " failed to complete. ")
         else:
-            if job.config.NOTIFY_TRANSCODE:
+            if cfg["NOTIFY_TRANSCODE"]:
                 utils.notify(job, "ARM notification", str(job.title) + " processing complete. ")
             logging.info("ARM processing complete")
 
@@ -447,10 +435,10 @@ def main(logfile, job):
 
     elif job.disctype == "data":
         # get filesystem in order
-        datapath = os.path.join(job.config.ARMPATH, str(job.label))
+        datapath = os.path.join(cfg["ARMPATH"], str(job.label))
         if (utils.make_dir(datapath)) is False:
             ts = str(round(time.time() * 100))
-            datapath = os.path.join(job.config.ARMPATH, str(job.label) + "_" + ts)
+            datapath = os.path.join(cfg["ARMPATH"], str(job.label) + "_" + ts)
 
             if (utils.make_dir(datapath)) is False:
                 logging.info("Could not create data directory: " + str(datapath) + ".  Exiting ARM. ")
@@ -507,13 +495,13 @@ if __name__ == "__main__":
     db.session.commit()
 
     # Log version number
-    with open(os.path.join(job.config.INSTALLPATH, 'VERSION')) as version_file:
+    with open(os.path.join(cfg["INSTALLPATH"], 'VERSION')) as version_file:
         version = version_file.read().strip()
     logging.info("ARM version: " + str(version))
     job.arm_version = version
     logging.info(("Python version: " + sys.version).replace('\n', ""))
     logging.info("User is: " + getpass.getuser())
-    logger.cleanuplogs(job.config.LOGPATH, job.config.LOGLIFE)
+    logger.cleanuplogs(cfg["LOGPATH"], cfg["LOGLIFE"])
     logging.info("Job: " + str(job.label))
 
     # a_jobs = Job.query.filter_by(status="active")

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -48,42 +48,23 @@ def log_arm_params(job):
 
     # log arm parameters
     logging.info("**** Logging ARM variables ****")
-    logging.info("devpath: " + str(job.devpath))
-    logging.info("mountpoint: " + str(job.mountpoint))
-    logging.info("title: " + str(job.title))
-    logging.info("year: " + str(job.year))
-    logging.info("video_type: " + str(job.video_type))
-    logging.info("hasnicetitle: " + str(job.hasnicetitle))
-    logging.info("label: " + str(job.label))
-    logging.info("disctype: " + str(job.disctype))
+    for key in ("devpath", "mountpoint", "title", "year", "video_type",
+                "hasnicetitle", "label", "disctype"):
+        logging.info(
+            key + ": " + str(getattr(job, key)))
     logging.info("**** End of ARM variables ****")
+
     logging.info("**** Logging config parameters ****")
-    logging.info("skip_transcode: " + str(job.config.SKIP_TRANSCODE))
-    logging.info("mainfeature: " + str(job.config.MAINFEATURE))
-    logging.info("minlength: " + job.config.MINLENGTH)
-    logging.info("maxlength: " + job.config.MAXLENGTH)
-    logging.info("videotype: " + job.config.VIDEOTYPE)
-    logging.info("manual_wait: " + str(job.config.MANUAL_WAIT))
-    logging.info("wait_time: " + str(job.config.MANUAL_WAIT_TIME))
-    logging.info("ripmethod: " + job.config.RIPMETHOD)
-    logging.info("mkv_args: " + job.config.MKV_ARGS)
-    logging.info("delrawfile: " + str(job.config.DELRAWFILES))
-    logging.info("hb_preset_dvd: " + job.config.HB_PRESET_DVD)
-    logging.info("hb_preset_bd: " + job.config.HB_PRESET_BD)
-    logging.info("hb_args_dvd: " + job.config.HB_ARGS_DVD)
-    logging.info("hb_args_bd: " + job.config.HB_ARGS_BD)
-    logging.info("logfile: " + logfile)
-    logging.info("armpath: " + job.config.ARMPATH)
-    logging.info("rawpath: " + job.config.RAWPATH)
-    logging.info("media_dir: " + job.config.MEDIA_DIR)
-    logging.info("extras_sub: " + job.config.EXTRAS_SUB)
-    logging.info("emby_refresh: " + str(job.config.EMBY_REFRESH))
-    logging.info("emby_server: " + job.config.EMBY_SERVER)
-    logging.info("emby_port: " + job.config.EMBY_PORT)
-    logging.info("notify_rip: " + str(job.config.NOTIFY_RIP))
-    logging.info("notify_transcode " + str(job.config.NOTIFY_TRANSCODE))
-    #  Added from pull 366
-    logging.info("max_concurrent_transcodes " + str(job.config.MAX_CONCURRENT_TRANSCODES))
+    for key in ("SKIP_TRANSCODE", "MAINFEATURE", "MINLENGTH", "MAXLENGTH",
+                "VIDEOTYPE", "MANUAL_WAIT", "MANUAL_WAIT_TIME", "RIPMETHOD",
+                "MKV_ARGS", "DELRAWFILES", "HB_PRESET_DVD", "HB_PRESET_BD",
+                "HB_ARGS_DVD", "HB_ARGS_BD", "ARMPATH", "RAWPATH",
+                "MEDIA_DIR", "EXTRAS_SUB", "EMBY_REFRESH", "EMBY_SERVER",
+                "EMBY_PORT", "NOTIFY_RIP", "NOTIFY_TRANSCODE",
+                "MAX_CONCURRENT_TRANSCODES"):
+        logging.info(key.lower() +
+                     ": " +
+                     str(getattr(job.config, key, '<not given>')))
     logging.info("**** End of config parameters ****")
 
 

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -6,7 +6,7 @@ import subprocess
 import time
 import shlex
 
-# from arm.config.config import cfg
+from arm.config.config import cfg
 from arm.ripper import utils  # noqa: E402
 from arm.ui import db  # noqa: F401, E402
 
@@ -20,7 +20,7 @@ def makemkv(logfile, job):
     Returns path to ripped files.
     """
 
-    logging.info("Starting MakeMKV rip. Method is " + job.config.RIPMETHOD)
+    logging.info("Starting MakeMKV rip. Method is " + cfg["RIPMETHOD"])
 
     # get MakeMKV disc number
     logging.debug("Getting MakeMKV disc number")
@@ -41,7 +41,7 @@ def makemkv(logfile, job):
         raise RuntimeError(err)
 
     # get filesystem in order
-    rawpath = os.path.join(str(job.config.RAWPATH), str(job.title))
+    rawpath = os.path.join(str(cfg["RAWPATH"]), str(job.title))
     logging.info("Destination is " + str(rawpath))
 
     if not os.path.exists(rawpath):
@@ -54,7 +54,7 @@ def makemkv(logfile, job):
     else:
         logging.info(rawpath + " exists.  Adding timestamp.")
         ts = round(time.time() * 100)
-        rawpath = os.path.join(str(job.config.RAWPATH), str(job.title) + "_" + str(ts))
+        rawpath = os.path.join(str(cfg["RAWPATH"]), str(job.title) + "_" + str(ts))
         logging.info("rawpath is " + str(rawpath))
         try:
             os.makedirs(rawpath)
@@ -64,10 +64,10 @@ def makemkv(logfile, job):
             sys.exit(err)
 
     # rip bluray
-    if job.config.RIPMETHOD == "backup" and job.disctype == "bluray":
+    if cfg["RIPMETHOD"] == "backup" and job.disctype == "bluray":
         # backup method
         cmd = 'makemkvcon backup --decrypt {0} -r disc:{1} {2}>> {3}'.format(
-            job.config.MKV_ARGS,
+            cfg["MKV_ARGS"],
             mdisc.strip(),
             shlex.quote(rawpath),
             logfile
@@ -95,18 +95,18 @@ def makemkv(logfile, job):
             # print("Error: " + mkv)
             return None
 
-    elif job.config.RIPMETHOD == "mkv" or job.disctype == "dvd":
+    elif cfg["RIPMETHOD"] == "mkv" or job.disctype == "dvd":
         # mkv method
         get_track_info(mdisc, job)
 
         # if no maximum length, process the whole disc in one command
-        if int(job.config.MAXLENGTH) > 99998:
+        if int(cfg["MAXLENGTH"]) > 99998:
             cmd = 'makemkvcon mkv {0} -r dev:{1} {2} {3} --minlength={4}>> {5}'.format(
-                job.config.MKV_ARGS,
+                cfg["MKV_ARGS"],
                 job.devpath,
                 "all",
                 shlex.quote(rawpath),
-                job.config.MINLENGTH,
+                cfg["MINLENGTH"],
                 logfile
             )
             logging.debug("Ripping with the following command: " + cmd)
@@ -133,16 +133,16 @@ def makemkv(logfile, job):
         else:
             # process one track at a time based on track length
             for track in job.tracks:
-                if track.length < int(job.config.MINLENGTH):
+                if track.length < int(cfg["MINLENGTH"]):
                     # too short
                     logging.info("Track #" + str(track.track_number) + " of " + str(job.no_of_titles) + ". Length ("
                                  + str(track.length)
-                                 + ") is less than minimum length (" + job.config.MINLENGTH + ").  Skipping")
-                elif track.length > int(job.config.MAXLENGTH):
+                                 + ") is less than minimum length (" + cfg["MINLENGTH"] + ").  Skipping")
+                elif track.length > int(cfg["MAXLENGTH"]):
                     # too long
                     logging.info("Track #" + str(track.track_number) + " of " + str(job.no_of_titles)
                                  + ". Length (" + str(track.length) +
-                                 ") is greater than maximum length (" + job.config.MAXLENGTH + ").  Skipping")
+                                 ") is greater than maximum length (" + cfg["MAXLENGTH"] + ").  Skipping")
                 else:
                     # just right
                     logging.info("Processing track #" + str(track.track_number) + " of " + str(job.no_of_titles - 1)
@@ -158,11 +158,11 @@ def makemkv(logfile, job):
                     # db.session.commit()
 
                     cmd = 'makemkvcon mkv {0} -r dev:{1} {2} {3} --minlength={4}>> {5}'.format(
-                        job.config.MKV_ARGS,
+                        cfg["MKV_ARGS"],
                         job.devpath,
                         str(track.track_number),
                         shlex.quote(rawpath),
-                        job.config.MINLENGTH,
+                        cfg["MINLENGTH"],
                         logfile
                     )
                     logging.debug("Ripping with the following command: " + cmd)

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -14,7 +14,7 @@ import random
 import re
 import psutil
 
-# from arm.config.config import cfg
+from arm.config.config import cfg
 from arm.ui import app, db
 from arm.models.models import Track, Job
 
@@ -26,12 +26,12 @@ def notify(job, title, body):
     """
     # Pushbullet
     # pbul://{accesstoken}
-    if job.config.PB_KEY != "":
+    if cfg["PB_KEY"] != "":
         try:
             # Create an Apprise instance
             apobj = apprise.Apprise()
             # A sample pushbullet notification
-            apobj.add('pbul://' + str(job.config.PB_KEY))
+            apobj.add('pbul://' + str(cfg["PB_KEY"]))
             # Then notify these services any time you desire. The below would
             # notify all of the services loaded into our Apprise object.
             apobj.notify(
@@ -42,12 +42,12 @@ def notify(job, title, body):
             logging.error("Failed sending Pushbullet apprise notification.  Continuing processing...")
     # IFTTT
     # ifttt://{WebhookID}@{Event}/
-    if job.config.IFTTT_KEY != "":
+    if cfg["IFTTT_KEY"] != "":
         try:
             # Create an Apprise instance
             apobj = apprise.Apprise()
             # A sample pushbullet notification
-            apobj.add('ifttt://' + str(job.config.IFTTT_KEY) + "@" + str(job.config.IFTTT_EVENT))
+            apobj.add('ifttt://' + str(cfg["IFTTT_KEY"]) + "@" + str(cfg["IFTTT_EVENT"]))
 
             # Then notify these services any time you desire. The below would
             # notify all of the services loaded into our Apprise object.
@@ -58,12 +58,12 @@ def notify(job, title, body):
         except:  # noqa: E722
             logging.error("Failed sending IFTTT apprise notification.  Continuing processing...")
     # PUSHOVER
-    if job.config.PO_USER_KEY != "":
+    if cfg["PO_USER_KEY"] != "":
         try:
             # Create an Apprise instance
             apobj = apprise.Apprise()
 
-            apobj.add('pover://' + str(job.config.PO_USER_KEY) + "@" + str(job.config.PO_APP_KEY))
+            apobj.add('pover://' + str(cfg["PO_USER_KEY"]) + "@" + str(cfg["PO_APP_KEY"]))
             # Then notify these services any time you desire. The below would
             # notify all of the services loaded into our Apprise object.
             apobj.notify(
@@ -72,10 +72,10 @@ def notify(job, title, body):
             )
         except:  # noqa: E722
             logging.error("Failed sending PUSHOVER apprise notification.  continuing  processing...")
-    if job.config.APPRISE != "":
+    if cfg["APPRISE"] != "":
         try:
-            apprise_notify(job.config.APPRISE, title, body)
-            logging.debug("apprise-config: " + str(job.config.APPRISE))
+            apprise_notify(cfg["APPRISE"], title, body)
+            logging.debug("apprise-config: " + str(cfg["APPRISE"]))
         except Exception as e:  # noqa: E722
             logging.error("Failed sending apprise notification. " + str(e))
 
@@ -772,9 +772,9 @@ def apprise_notify(apprise_cfg, title, body):
 def scan_emby(job):
     """Trigger a media scan on Emby"""
 
-    if job.config.EMBY_REFRESH:
+    if cfg["EMBY_REFRESH"]:
         logging.info("Sending Emby library scan request")
-        url = f"http://{job.config.EMBY_SERVER}:{job.config.EMBY_PORT}/Library/Refresh?api_key={job.config.EMBY_API_KEY}"
+        url = f"http://{cfg['EMBY_SERVER']}:{cfg['EMBY_PORT']}/Library/Refresh?api_key={cfg['EMBY_API_KEY']}"
         try:
             req = requests.post(url)
             if req.status_code > 299:
@@ -833,7 +833,7 @@ def move_files(basepath, filename, job, ismainfeature=False):
     logging.debug(f"Arguments: {basepath} : {filename} : {hasnicetitle} : {videotitle} : {ismainfeature}")
 
     if hasnicetitle:
-        m_path = os.path.join(job.config.MEDIA_DIR + videotitle)
+        m_path = os.path.join(cfg["MEDIA_DIR"] + videotitle)
 
         if not os.path.exists(m_path):
             logging.info("Creating base title directory: " + m_path)
@@ -842,7 +842,7 @@ def move_files(basepath, filename, job, ismainfeature=False):
         if ismainfeature is True:
             logging.info("Track is the Main Title.  Moving '" + filename + "' to " + m_path)
 
-            m_file = os.path.join(m_path, videotitle + "." + job.config.DEST_EXT)
+            m_file = os.path.join(m_path, videotitle + "." + cfg["DEST_EXT"])
             if not os.path.isfile(m_file):
                 try:
                     shutil.move(os.path.join(basepath, filename), m_file)
@@ -851,7 +851,7 @@ def move_files(basepath, filename, job, ismainfeature=False):
             else:
                 logging.info("File: " + m_file + " already exists.  Not moving.")
         else:
-            e_path = os.path.join(m_path, job.config.EXTRAS_SUB)
+            e_path = os.path.join(m_path, cfg["EXTRAS_SUB"])
 
             if not os.path.exists(e_path):
                 logging.info("Creating extras directory " + e_path)
@@ -859,7 +859,7 @@ def move_files(basepath, filename, job, ismainfeature=False):
 
             logging.info("Moving '" + filename + "' to " + e_path)
 
-            e_file = os.path.join(e_path, videotitle + "." + job.config.DEST_EXT)
+            e_file = os.path.join(e_path, videotitle + "." + cfg["DEST_EXT"])
             if not os.path.isfile(e_file):
                 try:
                     shutil.move(os.path.join(basepath, filename), os.path.join(e_path, filename))
@@ -883,9 +883,9 @@ def rename_files(oldpath, job):
     # Check if the job has a nice title after rip is complete, if so use the media dir not the arm
     # This is for media that was recognised after the wait period/disk started ripping
     if job.hasnicetitle:
-        newpath = os.path.join(job.config.MEDIA_DIR, job.title + " (" + str(job.year) + ")")
+        newpath = os.path.join(cfg["MEDIA_DIR"], job.title + " (" + str(job.year) + ")")
     else:
-        newpath = os.path.join(job.config.ARMPATH, job.title + " (" + str(job.year) + ")")
+        newpath = os.path.join(cfg["ARMPATH"], job.title + " (" + str(job.year) + ")")
 
     logging.debug("oldpath: " + oldpath + " newpath: " + newpath)
     logging.info("Changing directory name from " + oldpath + " to " + newpath)
@@ -982,7 +982,7 @@ def rip_music(job, logfile):
     returns True/False for success/fail
     """
 
-    abcfile = job.config.ABCDE_CONFIG_FILE
+    abcfile = cfg["ABCDE_CONFIG_FILE"]
     if job.disctype == "music":
         logging.info("Disc identified as music")
         # If user has set a cfg file with ARM use it
@@ -1033,7 +1033,7 @@ def rip_data(job, datapath, logfile):
         cmd = 'dd if="{0}" of="{1}" {2} 2>> {3}'.format(
             job.devpath,
             incomplete_filename,
-            job.config.DATA_RIP_PARAMETERS,
+            cfg["DATA_RIP_PARAMETERS"],
             logfile
         )
 
@@ -1058,16 +1058,16 @@ def rip_data(job, datapath, logfile):
 
 def set_permissions(job, directory_to_traverse):
     try:
-        corrected_chmod_value = int(str(job.config.CHMOD_VALUE), 8)
-        logging.info("Setting permissions to: " + str(job.config.CHMOD_VALUE) + " on: " + directory_to_traverse)
+        corrected_chmod_value = int(str(cfg["CHMOD_VALUE"]), 8)
+        logging.info("Setting permissions to: " + str(cfg["CHMOD_VALUE"]) + " on: " + directory_to_traverse)
         os.chmod(directory_to_traverse, corrected_chmod_value)
 
         for dirpath, l_directories, l_files in os.walk(directory_to_traverse):
             for cur_dir in l_directories:
-                logging.debug("Setting path: " + cur_dir + " to permissions value: " + str(job.config.CHMOD_VALUE))
+                logging.debug("Setting path: " + cur_dir + " to permissions value: " + str(cfg["CHMOD_VALUE"]))
                 os.chmod(os.path.join(dirpath, cur_dir), corrected_chmod_value)
             for cur_file in l_files:
-                logging.debug("Setting file: " + cur_file + " to permissions value: " + str(job.config.CHMOD_VALUE))
+                logging.debug("Setting file: " + cur_file + " to permissions value: " + str(cfg["CHMOD_VALUE"]))
                 os.chmod(os.path.join(dirpath, cur_file), corrected_chmod_value)
         return True
     except Exception as e:
@@ -1086,7 +1086,7 @@ def check_db_version(install_path, db_file):
     import sqlite3
     import flask_migrate
 
-    # db_file = job.config.DBFILE
+    # db_file = cfg["DBFILE"]
     mig_dir = os.path.join(install_path, "arm/migrations")
 
     config = Config()
@@ -1183,7 +1183,6 @@ def arm_setup():
     :return
     None
     """
-    from arm.config.config import cfg
     try:
         # Make the ARM dir if it doesnt exist
         if not os.path.exists(cfg['ARMPATH']):

--- a/arm/ui/routes.py
+++ b/arm/ui/routes.py
@@ -612,12 +612,14 @@ def changeparams():
     # app.logger.debug(config.pretty_table())
     job = Job.query.get(config_id)
     config = job.config
+    for key, value in cfg.items():
+        setattr(config, key, value)
     form = ChangeParamsForm(obj=config)
     if form.validate_on_submit():
-        config.MINLENGTH = format(form.MINLENGTH.data)
-        config.MAXLENGTH = format(form.MAXLENGTH.data)
-        config.RIPMETHOD = format(form.RIPMETHOD.data)
-        config.MAINFEATURE = bool(format(form.MAINFEATURE.data))  # must be 1 for True 0 for False
+        cfg["MINLENGTH"] = config.MINLENGTH = format(form.MINLENGTH.data)
+        cfg["MAXLENGTH"] = config.MAXLENGTH = format(form.MAXLENGTH.data)
+        cfg["RIPMETHOD"] = config.RIPMETHOD = format(form.RIPMETHOD.data)
+        cfg["MAINFEATURE"] = config.MAINFEATURE = bool(format(form.MAINFEATURE.data))  # must be 1 for True 0 for False
         app.logger.debug(f"main={config.MAINFEATURE}")
         job.disctype = format(form.DISCTYPE.data)
         db.session.commit()


### PR DESCRIPTION
I keep getting these annoying errors with `job.config` lacking attributes. 

```
[11-03-2021 06:25:14] ERROR ARM: main.<module> A fatal error has occurred and ARM is exiting.  See traceback below for details.
Traceback (most recent call last):
  File "/opt/arm/arm/ripper/main.py", line 516, in <module>
    main(logfile, job)
  File "/opt/arm/arm/ripper/main.py", line 169, in main
    log_arm_params(job)
  File "/opt/arm/arm/ripper/main.py", line 74, in log_arm_params
    logging.info("max_concurrent_transcodes " + str(job.config.MAX_CONCURRENT_TRANSCODES))
AttributeError: 'Config' object has no attribute 'MAX_CONCURRENT_TRANSCODES'
```

This fixes it for now and seems to be better code anyway. But I have to dig into it later and find the real source of these errors, since I had all the parameters set in `arm.yaml`.