### PR TITLE
suggestions for Dockerfile that enable a better .abcde.conf file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,8 @@ RUN \
   apt update -y && \
   DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
     abcde \
+    eyed3 \
+    atomicparsley \
     cdparanoia \
     eject \
     ffmpeg \


### PR DESCRIPTION
This PR is a suggestion for the Dockerfile which adds eyed3 and atomicparsley so that we can use the awesome post-encode function to embed album art for m4a, flac and mp3 at the same time. See https://www.andrews-corner.org/abcde/getalbumart.html#embedall