### PR TITLE
Added Gentoo Install Script for OpenRC based systems

### DIFF
--- a/arm/models/models.py
+++ b/arm/models/models.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import pyudev
 import psutil
 import logging
@@ -67,6 +68,12 @@ class Job(db.Model):
             self.video_type = cfg['VIDEOTYPE']
         self.parse_udev()
         self.get_pid()
+
+        if self.disctype == "dvd" and (self.label == "" or self.label == None):
+            logging.info("No disk label Available. Trying lsdvd")
+            command = f"lsdvd {devpath} | grep 'Disc Title' | cut -d ' ' -f 3-"
+            lsdvdlbl = str(subprocess.check_output(command, shell=True).strip(),'utf-8')
+            self.label = lsdvdlbl
 
     def parse_udev(self):
         """Parse udev for properties of current disc"""

--- a/arm/models/models.py
+++ b/arm/models/models.py
@@ -69,10 +69,10 @@ class Job(db.Model):
         self.parse_udev()
         self.get_pid()
 
-        if self.disctype == "dvd" and (self.label == "" or self.label == None):
+        if self.disctype == "dvd" and not self.label:
             logging.info("No disk label Available. Trying lsdvd")
             command = f"lsdvd {devpath} | grep 'Disc Title' | cut -d ' ' -f 3-"
-            lsdvdlbl = str(subprocess.check_output(command, shell=True).strip(),'utf-8')
+            lsdvdlbl = str(subprocess.check_output(command, shell=True).strip(), 'utf-8')
             self.label = lsdvdlbl
 
     def parse_udev(self):

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -242,8 +242,8 @@ def main(logfile, job):
                 db.session.commit()
                 sys.exit()
 
-        # Use FFMPeg to convert Large Poster
-        if job.disctype == "dvd":
+        # Use FFMPeg to convert Large Poster if enabled in config
+        if job.disctype == "dvd" and cfg["RIP_POSTER"]:
             os.system("mount " + job.devpath)
             if os.path.isfile(job.mountpoint+"/JACKET_P/J00___5L.MP2"):
                 logging.info("Converting NTSC Poster Image")

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -340,7 +340,7 @@ def main(logfile, job):
                 except Exception as e:
                     logging.error(f"Unable to move poster.png to '{final_directory}' - Error: {e}")
             else:
-                logging.info(f"File: poster.png already exists.  Not moving.")
+                logging.info("File: poster.png already exists.  Not moving.")
 
         utils.scan_emby(job)
         utils.set_permissions(job, final_directory)

--- a/arm/ui/comments.json
+++ b/arm/ui/comments.json
@@ -30,6 +30,7 @@
     "DATA_RIP_PARAMETERS": "# Additional parameters for dd. e.g. \"conv=noerror,sync\" for ignoring read errors",
     "METADATA_PROVIDER": "# This selects the metadata provider, Each provider has their own ups and downs\n# But a general rule would be \n# OMDB for movies and shows \n# TMDB for movies only\n# You will still need to provide an api key for the provider you have selected",
     "GET_AUDIO_TITLE": "# Set to one of \"none\", \"musicbrainz\", \"freecddb\"\n# if \"musicbrainz\" is used the disc information are asked from musicbrainz.org\n# if \"none\" is used no label is identified",
+    "RIP_POSTER": "# Rip DVD Posters from JACKET_P folder\n# Requires FFmpeg",
     "ABCDE_CONFIG_FILE": "# Location of your ABCDE config file",
     "RAW_PATH": "# Path to raw MakeMKV directory\n# Destination for MakeMKV and source for HandBrake",
     "TRANSCODE_PATH": "# Intermediary directory for transcoding files\n# Destination for HandBrake",

--- a/docs/arm.yaml.sample
+++ b/docs/arm.yaml.sample
@@ -91,14 +91,18 @@ METADATA_PROVIDER: "omdb"
 # if "none" is used no label is identified
 GET_AUDIO_TITLE: "musicbrainz"
 
-# Location of your ABCDE config file
-# This over-rides any other abcde.conf files
-ABCDE_CONFIG_FILE: "/etc/abcde.conf"
+# Rip DVD Posters from JACKET_P folder
+# Requires FFmpeg
+RIP_POSTER: false
 
 
 #####################
 ## Directory setup ##
 #####################
+
+# Location of your ABCDE config file
+# This over-rides any other abcde.conf files
+ABCDE_CONFIG_FILE: "/etc/abcde.conf"
 
 # Path to raw MakeMKV directory
 # Destination for MakeMKV and source for HandBrake

--- a/docs/arm.yaml.sample
+++ b/docs/arm.yaml.sample
@@ -10,7 +10,7 @@ ARM_NAME: ""
 
 # ARM_CHILDREN
 # Comma delimited list of child ARM servers to display on the Home Page
-# Should be full protocol, path and port: http://192.168.0.100:8080
+# Should be full protocol, path, and port: http://192.168.0.100:8080
 ARM_CHILDREN: ""
 
 # Prevent ARM from wasting time on 99 Title protected DVDs.
@@ -81,8 +81,8 @@ DATA_RIP_PARAMETERS: ""
 
 # This selects the metadata provider, Each provider has their own ups and downs
 # But a general rule would be
-# OMDB for movies and shows
-# TMDB for movies only
+#    OMDB for movies and shows
+#    TMDB for movies only
 # You will still need to provide an api key for the provider you have selected
 METADATA_PROVIDER: "omdb"
 
@@ -308,6 +308,7 @@ TMDB_API_KEY: ""
 # JSON_URL
 # Url to send Notifications to in JSON format
 JSON_URL: ""
+
 
 #################################################
 ##            APPRISE NOTIFICATIONS            ##

--- a/scripts/gentoo-setup-openrc.sh
+++ b/scripts/gentoo-setup-openrc.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+
+###################################################################################################
+# Setup automatic-ripping-machine (ARM) for Gentoo systems running OpenRC.
+###################################################################################################
+
+# Exit on error.
+set -e
+
+RED='\033[1;31m'
+NC='\033[0m' # No Color
+
+echo -e "${RED}Adding arm user${NC}"
+if [ ! $(getent group arm) ]; then
+	groupadd arm
+fi
+
+if [ ! $(getent passwd arm) ]; then
+	useradd -m arm -g arm -G cdrom,video,audio
+	# If a password was specified use that, otherwise prompt
+	if [ -n "$1" ]; then
+		echo "$1" | passwd --stdin arm
+	else
+		passwd arm
+	fi
+fi
+
+# Install, but don't reinstall, packages or add them to world
+################################################################################
+
+function mergeifneeded() {
+	if [ ! -e /usr/bin/eix ]; then
+		emerge -a app-portage/eix
+		eix-update
+	fi
+
+	installed=$(eix -I $1) || true
+	if [ "$installed" = "No matches found" ]; then
+		# Not installed at all
+		emerge -a $1
+	else
+		if ! grep -qE "^${1}$" /var/lib/portage/world; then
+			# installed but not in world, add to world
+			emerge --noreplace $1
+		fi
+	fi
+}
+
+echo
+echo -e "${RED}Installing Packages${NC}"
+echo This script will stop for any issues such as licenses or use flags.
+echo Resolve the issue and rerun the script.
+echo How to resolve the issue is beyond the scope of this script.
+echo
+echo To watch emerge progress in another window use:
+echo '    watch -c "genlop -c"'
+echo
+echo You may need to emerge genlop first.
+echo
+#provides equery for later use
+mergeifneeded app-portage/gentoolkit
+
+#non-Gentoo specific packages
+mergeifneeded dev-vcs/git
+mergeifneeded media-video/makemkv
+mergeifneeded media-video/ffmpeg
+mergeifneeded media-video/handbrake
+mergeifneeded media-libs/libdvdcss
+mergeifneeded media-sound/abcde
+mergeifneeded media-libs/flac
+mergeifneeded media-gfx/imagemagick
+mergeifneeded media-libs/glyr
+mergeifneeded media-sound/cdparanoia
+mergeifneeded sys-process/at
+mergeifneeded dev-python/pip
+mergeifneeded media-video/lsdvd
+
+#java jre
+installed=$(eix -I virtual/jre) || true
+if [ "$installed" = "No matches found" ]; then
+	echo
+	echo -e "${RED}Configuring a Jave Runtime${NC}"
+	echo This script will merge virtual/jre but the actual JRE installed
+	echo will vary based upon your USE flags and configuration.
+	echo
+	echo Because of this it is not possible to automatically configure the
+	echo merged package to be headless. If you would like your installed
+	echo JRE running in a headless mode you should add USE flags to the
+	echo package.use file in /etc/portage for the JRE being merged.
+	echo
+	echo '   dev-java/jre-package    headless-awt -alsa -cups'
+	echo
+	echo Replacing jre-package with the name of your actual JRE.
+	echo
+	echo The next command to run will show you which JRE will be merged.
+	echo You can use enter no when prompted to stop the installation and
+	echo update your package.use file as needed.
+	echo
+	read -n1 -s -r -p $'Press Enter to continue...\n' key
+	emerge -a virtual/jre
+fi
+
+
+# Git Clone the ARM project
+################################################################################
+
+echo
+echo -e "${RED}Installing ARM:Automatic Ripping Machine${NC}"
+cd /opt
+
+if [ ! -d arm ]; then
+	mkdir -p /opt/arm
+fi
+
+chown arm:arm arm
+chmod 775 arm
+
+if [ -d /opt/arm/.git ]; then
+	cd /opt/arm
+	git fetch
+	cd /opt
+else
+	git clone https://github.com/mneimeyer/automatic-ripping-machine.git arm
+
+	##Upstream
+	#git clone https://github.com/1337-server/automatic-ripping-machine.git arm
+
+	###stock
+	#git clone https://github.com/automatic-ripping-machine/automatic-ripping-machine.git arm
+fi
+
+chown -R arm:arm arm
+cd arm
+
+# Try to convert requirements.txt into ebuilds, otherwise install for arm user
+################################################################################
+
+echo
+echo -e "${RED}Installing Required Python Libraries${NC}"
+for line in $(cat requirements.txt) ; do
+
+	reqpkg=$(echo $line | cut -d '>' -f 1 | tr '[:upper:]' '[:lower:]')
+
+	if [ -d /var/db/repos/gentoo/dev-python/$reqpkg ]; then
+		reqpkg="dev-python/${reqpkg}"
+		mergeifneeded $reqpkg
+	else
+		if [ -d /var/db/repos/gentoo/dev-python/python-$reqpkg ]; then
+			reqpkg="dev-python/python-${reqpkg}"
+			mergeifneeded $reqpkg
+		else
+			/bin/su -l -c "/usr/bin/pip install --user ${line}" -s /bin/bash arm
+		fi
+	fi
+
+done
+
+# Link and Copy
+################################################################################
+
+ln -s /opt/arm/setup/51-automedia.rules /lib/udev/rules.d/
+ln -s /opt/arm/setup/.abcde.conf /home/arm/
+cp docs/arm.yaml.sample arm.yaml
+mkdir -p /etc/arm/
+ln -s /opt/arm/arm.yaml /etc/arm/
+chmod +x /opt/arm/scripts/arm_wrapper.sh
+
+# System Files
+################################################################################
+
+echo
+echo -e "${RED}Adding fstab entry and creating mount points${NC}"
+for dev in /dev/sr?; do
+   #echo -e "\n${dev}  /mnt${dev}  udf,iso9660  users,noauto,exec,utf8  0  0 \n" >> /etc/fstab
+   mkdir -p /mnt$dev
+done
+
+##### Add sysctl.d rule to prevent auto-unejecting cd tray
+cat > /etc/sysctl.d/arm-uneject-fix.conf <<-EOM
+# Fix issue with DVD tray being autoclosed after rip is complete
+
+dev.cdrom.autoclose=0
+EOM
+
+##### Add syslog rule to route all ARM system logs to /var/log/arm.log
+if [ -d /etc/rsyslog.d ]; then
+	cat > /etc/rsyslog.d/arm.conf <<-EOM
+:programname, isequal, "ARM" /var/log/arm.log
+EOM
+	/etc/init.d/rsyslog restart
+fi
+
+if ! grep -qE "^ARM :$" /etc/metalog.conf; then
+	echo '' >> /etc/metalog.conf
+	echo 'ARM :' >> /etc/metalog.conf
+	echo '    regex  = "^arm"' >> /etc/metalog.conf
+	echo '    logdir = "/var/log/arm"' >> /etc/metalog.conf
+	echo '    break  = 1' >> /etc/metalog.conf
+	echo '' >> /etc/metalog.conf
+
+	/etc/init.d/metalog restart
+fi
+
+##### Run the ARM UI as a service.
+echo -e "${RED}Installing OpenRC ARM service${NC}"
+cat > /etc/init.d/armui <<- EOM
+#!/sbin/openrc-run
+
+depend() {
+        need net
+}
+
+start() {
+        /bin/su -l -c "/usr/bin/python3 /opt/arm/arm/runui.py 2>&1 >/dev/null &" -s /bin/bash arm
+}
+
+stop() {
+        pkill -u arm -9 -f "runui.py"
+}
+EOM
+
+##### Add the armui and atd service to the default runlevel
+chmod +x /etc/init.d/armui
+/sbin/rc-update add armui default
+/etc/init.d/armui start
+
+/sbin/rc-update add atd default
+/etc/init.d/atd start
+
+#advise to reboot
+echo
+echo -e "${RED}We recommend rebooting your system at this time.${NC}"
+echo

--- a/scripts/gentoo-setup-openrc.sh
+++ b/scripts/gentoo-setup-openrc.sh
@@ -48,6 +48,13 @@ function mergeifneeded() {
 
 echo
 echo -e "${RED}Installing Packages${NC}"
+echo This script was developed for OpenRC based Gentoo Systems
+echo
+echo The "default/linux/amd64/17.1/desktop/plasma (stable)" profile
+echo was selected and the kde-plasma/plasma-meta package was installed.
+echo If your profile or desktop environment differ you may need to
+echo adjust this script.
+echo
 echo This script will stop for any issues such as licenses or use flags.
 echo Resolve the issue and rerun the script.
 echo How to resolve the issue is beyond the scope of this script.
@@ -57,6 +64,7 @@ echo '    watch -c "genlop -c"'
 echo
 echo You may need to emerge genlop first.
 echo
+
 #provides equery for later use
 mergeifneeded app-portage/gentoolkit
 

--- a/scripts/gentoo-setup-openrc.sh
+++ b/scripts/gentoo-setup-openrc.sh
@@ -93,13 +93,12 @@ if [ "$installed" = "No matches found" ]; then
 	echo Replacing jre-package with the name of your actual JRE.
 	echo
 	echo The next command to run will show you which JRE will be merged.
-	echo You can use enter no when prompted to stop the installation and
+	echo You can enter no when prompted to stop the installation and
 	echo update your package.use file as needed.
 	echo
 	read -n1 -s -r -p $'Press Enter to continue...\n' key
 	emerge -a virtual/jre
 fi
-
 
 # Git Clone the ARM project
 ################################################################################
@@ -120,10 +119,7 @@ if [ -d /opt/arm/.git ]; then
 	git fetch
 	cd /opt
 else
-	git clone https://github.com/mneimeyer/automatic-ripping-machine.git arm
-
-	##Upstream
-	#git clone https://github.com/1337-server/automatic-ripping-machine.git arm
+	git clone https://github.com/1337-server/automatic-ripping-machine.git arm
 
 	###stock
 	#git clone https://github.com/automatic-ripping-machine/automatic-ripping-machine.git arm
@@ -140,6 +136,8 @@ echo -e "${RED}Installing Required Python Libraries${NC}"
 for line in $(cat requirements.txt) ; do
 
 	reqpkg=$(echo $line | cut -d '>' -f 1 | tr '[:upper:]' '[:lower:]')
+
+	#TODO: Probably not completely safe to check for repo directory
 
 	if [ -d /var/db/repos/gentoo/dev-python/$reqpkg ]; then
 		reqpkg="dev-python/${reqpkg}"
@@ -183,12 +181,17 @@ dev.cdrom.autoclose=0
 EOM
 
 ##### Add syslog rule to route all ARM system logs to /var/log/arm.log
+
+# TODO: Untested, not installed on dev system
+
 if [ -d /etc/rsyslog.d ]; then
 	cat > /etc/rsyslog.d/arm.conf <<-EOM
 :programname, isequal, "ARM" /var/log/arm.log
 EOM
 	/etc/init.d/rsyslog restart
 fi
+
+# TODO: Doesn't seem to be working
 
 if ! grep -qE "^ARM :$" /etc/metalog.conf; then
 	echo '' >> /etc/metalog.conf

--- a/scripts/gentoo-setup-openrc.sh
+++ b/scripts/gentoo-setup-openrc.sh
@@ -108,6 +108,31 @@ if [ "$installed" = "No matches found" ]; then
 	emerge -a virtual/jre
 fi
 
+# Handbrake 1.3 is not compatible with FFMpeg 4.4
+################################################################################
+
+version_greater_equal() {
+    printf '%s\n%s\n' "$2" "$1" | sort --check=quiet --version-sort
+}
+
+hb_ver=$(eix -I handbrake | grep "Installed versions:" | tr -s " " | cut -d " " -f 4 | cut -d "-" -f 1)
+ff_ver=$(eix -I ffmpeg    | grep "Installed versions:" | tr -s " " | cut -d " " -f 4 | cut -d "-" -f 1)
+
+echo Handbrake: $hb_ver
+echo FFMpeg:    $ff_ver
+if ! version_greater_equal $hb_ver 1.4 && version_greater_equal $ff_ver 4.4 ; then
+	echo
+	echo -e "${RED}!!! Warning !!!${NC}"
+	echo
+	echo Versions of Handbrake prior to 1.4 do not officially support
+	echo FFmpeg 4.4. Common issues include the inability to properly
+	echo transcode audio resulting in silent media files.
+	echo
+	echo You may need to mask FFmpeg 4.4 until Handbrake 1.4 is available.
+	echo
+	read -n1 -s -r -p $'Press Enter to continue...\n' key
+fi
+
 # Git Clone the ARM project
 ################################################################################
 


### PR DESCRIPTION
With the caveat that Gentoo is a multi-headed beastie resulting from being an eminently configurable and rolling distro I offer this as at least a starting point. In other words, it works for me. :)

I personally do not run systemd, the other primary option for an init system on Gentoo, but I assume this could be expanded by adapting some portions of the Debian or Ubuntu install scripts. I also have not, and probably won't, develop a quiet version. Especially because of the variability of the JRE. Also, I like my scripts "loud".

Long run, it would probably be best to try and adapt this into an ebuild so that it can be more "Portage aware". I balked at that because I don't know of a way to parse the requirements.txt into DEPENDS lines "on the fly". Especially not before the git repository is cloned.

P.S. The Metalog facility for syslogging the ARM output is just borked.