### PR TITLE
Add tools to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ RUN \
     udev \
     wget \
     build-essential \
+    nano \
+    vi \
+    vim \
     && \
   DEBIAN_FRONTEND=noninteractive apt clean -y && \
   rm -rf /var/lib/apt/lists/* 


### PR DESCRIPTION
This pr adds the editor tools `nano`, `vi`, and `vim` to the tools installed in the Docker container, in response to Issue #109.