### PR TITLE
Duplication mitigations

### DIFF
--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -168,6 +168,7 @@ def main(logfile, job):
     identify.identify(job, logfile)
     # Check db for entries matching the crc and successful
     have_dupes, crc_jobs = utils.job_dupe_check(job)
+    logging.debug(f"Value of have_dupes: {have_dupes}")
 
     utils.notify_entry(job)
 
@@ -218,6 +219,8 @@ def main(logfile, job):
             logging.info(f"Handbrake Output directory \"{hb_out_path}\" already exists.")
             # Only begin ripping if we are allowed to make duplicates
             # Or the successful rip of the disc is not found in our database
+            logging.debug(f"Value of ALLOW_DUPLICATES: {0}".format(cfg["ALLOW_DUPLICATES"]))
+            logging.debug(f"Value of have_dupes: {have_dupes}")
             if cfg["ALLOW_DUPLICATES"] or not have_dupes:
                 ts = round(time.time() * 100)
                 hb_out_path = hb_out_path + "_" + str(ts)

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -534,8 +534,7 @@ def clean_old_jobs():
 
 def job_dupe_check(job):
     """
-    function for checking the database to look for jobs that have completed
-    successfully with the same crc
+    function for checking the database to look for jobs with the same crc that haven't failed
 
     :param job: The job obj so we can use the crc/title etc
     :return: True if we have found dupes with the same crc
@@ -546,7 +545,7 @@ def job_dupe_check(job):
     if job.crc_id is None:
         return False, None
     logging.debug(f"trying to find jobs with crc64={job.crc_id}")
-    previous_rips = m.Job.query.filter_by(crc_id=job.crc_id, status="success", hasnicetitle=True)
+    previous_rips = m.Job.query.filter(~m.Job.status.__contains__("fail"), crc_id=job.crc_id, hasnicetitle=True)
     r = {}
     i = 0
     for j in previous_rips:

--- a/arm/ui/utils.py
+++ b/arm/ui/utils.py
@@ -423,8 +423,7 @@ def get_omdb_poster(title=None, year=None, imdb_id=None, plot="short"):
 
 def job_dupe_check(crc_id):
     """
-    function for checking the database to look for jobs that have completed
-    successfully with the same crc
+    function for checking the database to look for jobs with the same crc that haven't failed
 
     :param crc_id: The job obj so we can use the crc/title etc
     :return: True if we have found dupes with the same crc
@@ -434,7 +433,7 @@ def job_dupe_check(crc_id):
     """
     if crc_id is None:
         return False, None
-    jobs = Job.query.filter_by(crc_id=crc_id, status="success", hasnicetitle=True)
+    jobs = Job.query.filter(~Job.status.__contains__("fail"), crc_id=crc_id, hasnicetitle=True)
     # app.logger.debug("search - posts=" + str(jobs))
     r = {}
     i = 0


### PR DESCRIPTION
These changes fix the edge case in the current filter queries, and adds debug logging to help ensure that values aren't being changed between assignment and usage. Right now, if a duplicate run occurs at anytime before the original rip completes (transcoding, etc.), it will not fail if there are no successful rips of the same disk stored in the database

To solve this, I have changed the filter statements from `WHERE status = "success"` to `WHERE NOT status = "fail"`. This will register active rips of the same disk as valid duplicates, handling this edge case.

Note this shouldn't affect TV series, as each disk should have a unique `crc`