### PR TITLE
fixes for broken queries

### DIFF
--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -534,7 +534,8 @@ def clean_old_jobs():
 
 def job_dupe_check(job):
     """
-    function for checking the database to look for jobs with the same crc that haven't failed
+    function for checking the database to look for jobs that have completed
+    successfully with the same crc
 
     :param job: The job obj so we can use the crc/title etc
     :return: True if we have found dupes with the same crc
@@ -545,9 +546,7 @@ def job_dupe_check(job):
     if job.crc_id is None:
         return False, None
     logging.debug(f"trying to find jobs with crc64={job.crc_id}")
-    previous_rips = m.Job.query.filter(not m.Job.status != "fail",
-                                       m.Job.crc_id == job.crc_id,
-                                       m.Job.hasnicetitle is True)
+    previous_rips = m.Job.query.filter_by(crc_id=job.crc_id, status="success", hasnicetitle=True)
     r = {}
     i = 0
     for j in previous_rips:

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -545,7 +545,9 @@ def job_dupe_check(job):
     if job.crc_id is None:
         return False, None
     logging.debug(f"trying to find jobs with crc64={job.crc_id}")
-    previous_rips = m.Job.query.filter(~m.Job.status.__contains__("fail"), crc_id=job.crc_id, hasnicetitle=True)
+    previous_rips = m.Job.query.filter(not m.Job.status != "fail",
+                                       m.Job.crc_id == job.crc_id,
+                                       m.Job.hasnicetitle is True)
     r = {}
     i = 0
     for j in previous_rips:

--- a/arm/ui/utils.py
+++ b/arm/ui/utils.py
@@ -433,7 +433,9 @@ def job_dupe_check(crc_id):
     """
     if crc_id is None:
         return False, None
-    jobs = Job.query.filter(~Job.status.__contains__("fail"), crc_id=crc_id, hasnicetitle=True)
+    jobs = Job.query.filter(not Job.status != "fail",
+                            Job.crc_id == crc_id,
+                            Job.hasnicetitle is True)
     # app.logger.debug("search - posts=" + str(jobs))
     r = {}
     i = 0

--- a/arm/ui/utils.py
+++ b/arm/ui/utils.py
@@ -423,7 +423,8 @@ def get_omdb_poster(title=None, year=None, imdb_id=None, plot="short"):
 
 def job_dupe_check(crc_id):
     """
-    function for checking the database to look for jobs with the same crc that haven't failed
+    function for checking the database to look for jobs that have completed
+    successfully with the same crc
 
     :param crc_id: The job obj so we can use the crc/title etc
     :return: True if we have found dupes with the same crc
@@ -433,9 +434,7 @@ def job_dupe_check(crc_id):
     """
     if crc_id is None:
         return False, None
-    jobs = Job.query.filter(not Job.status != "fail",
-                            Job.crc_id == crc_id,
-                            Job.hasnicetitle is True)
+    jobs = Job.query.filter_by(crc_id=crc_id, status="success", hasnicetitle=True)
     # app.logger.debug("search - posts=" + str(jobs))
     r = {}
     i = 0


### PR DESCRIPTION
Once I rebased on the PR, the query exploded because `__contains__` isn't implemented. These changes are confirmed working, and the calls are more neatly formatted.

EDIT: Belay this. for some reason the query is returning empty when it should be IDing repeats