### PR TITLE
[URGENT] Fix bug in file sorting

### DIFF
--- a/arm/ripper/handbrake.py
+++ b/arm/ripper/handbrake.py
@@ -197,8 +197,7 @@ def handbrake_mkv(srcpath, basepath, logfile, job):
         hb_preset = cfg["HB_PRESET_BD"]
 
     # This will fail if the directory raw gets deleted
-    # sorted makes sure we transcode each title in order
-    for f in sorted(srcpath, key=lambda x: int(x.replace('title_t', ''))):
+    for f in os.listdir(srcpath):
         srcpathname = os.path.join(srcpath, f)
         destfile = os.path.splitext(f)[0]
         filename = os.path.join(basepath, destfile + "." + cfg["DEST_EXT"])


### PR DESCRIPTION
This PR fixes a bug that causes a crash every time ARM tries to list the files to be run through handbrake. Please merge this before releasing v2.6.0.