### PR TITLE
Port parameter

### DIFF
--- a/scripts/ubuntu-20.04-install.sh
+++ b/scripts/ubuntu-20.04-install.sh
@@ -22,10 +22,14 @@ do
     p)    port_flag=1
           PORT=$OPTARG
           # test if port is valid (DOES NOT WORK WITH `set -u` DECLARED)
-          [[ $PORT -gt 0 && $PORT -le 65535 ]] || echo -e "\nERROR: ${PORT} is not a port" && usage && exit 1
+          if ! [[ $PORT -gt 0 && $PORT -le 65535 ]]; then
+              echo -e "\nERROR: ${PORT} is not a port"
+              usage
+              exit 1
+          fi
           ;;
     ?)    usage
-          exit 2
+          exit 1
           ;;
     esac
 done

--- a/scripts/ubuntu-20.04-install.sh
+++ b/scripts/ubuntu-20.04-install.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
+
+function usage() {
+    echo -e "\nUsage: ubuntu-20.04-install.sh [OPTIONS]"
+    echo -e "\t-d\t\tInstall the ARM Development Environment"
+    echo -e "\t-p [PORT]\tOverwrite the default WEBSERVER_PORT"
+}
 
 RED='\033[1;31m'
 NC='\033[0m' # No Color
@@ -14,11 +20,11 @@ do
     d)    dev_env_flag=1
           ;;
     p)    port_flag=1
-          PORT=$OPTION
+          PORT=$OPTARG
+          # test if port is valid (DOES NOT WORK WITH `set -u` DECLARED)
+          [[ $PORT -gt 0 && $PORT -le 65535 ]] || echo -e "\nERROR: ${PORT} is not a port" && usage && exit 1
           ;;
-    ?)    echo -e "\nUsage: ubuntu-20.04-install.sh [OPTIONS]"
-          echo -e "\t-d\t\tInstall the ARM Development Environment"
-          echo -e "\t-p [PORT]\tOverwrite the default WEBSERVER_PORT"
+    ?)    usage
           exit 2
           ;;
     esac
@@ -130,7 +136,7 @@ function create_abcde_symlink() {
 function create_arm_config_symlink() {
     if [[ $port_flag ]]; then
         echo -e "${RED}Non-default port specified, updating arm config...${NC}"
-        # replace the default 8080 port with the
+        # replace the default 8080 port with the specified port
         sed -e s"/\(^WEBSERVER_PORT:\) 8080/\1 ${PORT}/" -i /opt/arm/arm.yaml
     fi
 

--- a/scripts/ubuntu-20.04-install.sh
+++ b/scripts/ubuntu-20.04-install.sh
@@ -16,8 +16,10 @@ do
     p)    port_flag=1
           PORT=$OPTION
           ;;
-    ?)    echo "Usage: ubuntu-20.04-install.sh [ -d ]"
-          return 2
+    ?)    echo -e "\nUsage: ubuntu-20.04-install.sh [OPTIONS]"
+          echo -e "\t-d\t\tInstall the ARM Development Environment"
+          echo -e "\t-p [PORT]\tOverwrite the default WEBSERVER_PORT"
+          exit 2
           ;;
     esac
 done

--- a/scripts/ubuntu-20.04-install.sh
+++ b/scripts/ubuntu-20.04-install.sh
@@ -6,10 +6,15 @@ RED='\033[1;31m'
 NC='\033[0m' # No Color
 
 dev_env_flag=
+port_flag=
+PORT=8080
 while getopts 'dp:' OPTION
 do
     case $OPTION in
     d)    dev_env_flag=1
+          ;;
+    p)    port_flag=1
+          PORT=$OPTION
           ;;
     ?)    echo "Usage: ubuntu-20.04-install.sh [ -d ]"
           return 2
@@ -29,7 +34,7 @@ function install_os_tools() {
 function add_arm_user() {
     echo -e "${RED}Adding arm user${NC}"
     # create arm group if it doesn't already exist
-    if ! [ $(getent group arm) ]; then
+    if ! [[ $(getent group arm) ]]; then
         sudo groupadd arm
     else
         echo -e "${RED}arm group already exists, skipping...${NC}"
@@ -181,7 +186,7 @@ function setup_autoplay() {
         else
             echo -e "\n${dev}    /mnt${dev}    udf,iso9660    users,noauto,exec,utf8    0    0 \n" | sudo tee -a /etc/fstab
         fi
-        sudo mkdir -p /mnt$dev
+        sudo mkdir -p "/mnt$dev"
     done
 }
 
@@ -212,12 +217,12 @@ function install_armui_service() {
 
 function launch_setup() {
     echo -e "${RED}Launching ArmUI first-time setup${NC}"
-    site_addr=`sudo netstat -tlpn | awk '{ print $4 }' | grep .*:8080`
-    if [ -z $site_addr ]; then
+    site_addr=$(sudo netstat -tlpn | awk '{ print $4 }' | grep ".*:${PORT}")
+    if [ -z "$site_addr" ]; then
         echo -e "${RED}ERROR: ArmUI site is not running. Run \"sudo systemctl status armui\" to find out why${NC}"
     else
         echo -e "${RED}ArmUI site is running on http://$site_addr. Launching setup...${NC}"
-        sudo -u arm nohup xdg-open http://$site_addr/setup > /dev/null 2>&1 &
+        sudo -u arm nohup xdg-open "http://$site_addr/setup" > /dev/null 2>&1 &
     fi
 }
 

--- a/scripts/ubuntu-20.04-install.sh
+++ b/scripts/ubuntu-20.04-install.sh
@@ -126,6 +126,12 @@ function create_abcde_symlink() {
 }
 
 function create_arm_config_symlink() {
+    if [[ $port_flag ]]; then
+        echo -e "${RED}Non-default port specified, updating arm config...${NC}"
+        # replace the default 8080 port with the
+        sed -e s"/\(^WEBSERVER_PORT:\) 8080/\1 ${PORT}/" -i /opt/arm/arm.yaml
+    fi
+
     if ! [[ -z $(find /etc/arm/ -type l -ls | grep "arm.yaml") ]]; then
         rm /etc/arm/arm.yaml
     fi

--- a/scripts/ubuntu-20.04-install.sh
+++ b/scripts/ubuntu-20.04-install.sh
@@ -6,7 +6,7 @@ RED='\033[1;31m'
 NC='\033[0m' # No Color
 
 dev_env_flag=
-while getopts 'd' OPTION
+while getopts 'dp:' OPTION
 do
     case $OPTION in
     d)    dev_env_flag=1


### PR DESCRIPTION
This PR adds the `-p` parameter to `ubuntu-20.04-installer.sh` to set the port number to a non-default (8080) value at installation time.

Also tests to make sure the number entered is a valid port (0-65535)