### PR TITLE
Testing Refactoring of main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
-name: flake8
+name: "Quality Checks"
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the v2.5.0_dev branch
   push:
@@ -12,27 +12,68 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  
+
 jobs:
-  flake8_py3:
+  analyze:
+    name: Analyze
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript', 'python' ]
+
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-      - name: Checkout PyTorch
-        uses: actions/checkout@master
-      - name: Install flake8
-        run: pip install flake8
-      - name: Run flake8
-        uses: suo/flake8-github-action@releases/v1
-        with:
-          checkName: 'flake8_py3'   # NOTE: this needs to be the same as the job name
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v1.0.5
-        with:
-          fail_ci_if_error: false
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+  test-armui:
+    name: "Test A.R.M UI"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # in this example, there is a newer version already installed, 3.7.7, so the older version will be downloaded
+        python-version: ['3.6.0', '3.8', '3.9', '3.10']
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Fix dependencies
+      run: |
+        sudo apt-get install libgnutls28-dev libcurl4-openssl-dev libssl-dev libdiscid-dev
+    - name: Install A.R.M dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        flake8 . --max-complexity=15 --max-line-length=120 --show-source --statistics
+        # stop the build if there are Python syntax errors or undefined names
+        #flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Fix config files
+      run: |
+        cp docs/arm.yaml.sample arm.yaml
+    - name: Run A.R.M ui
+      run: timeout 1 python ./arm/runui.py || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi

--- a/arm/ripper/arm_ripper.py
+++ b/arm/ripper/arm_ripper.py
@@ -45,7 +45,7 @@ def rip_visual_media(have_dupes, job, logfile, protection):
     hb_in_path = str(job.devpath)
     # Do we need to use MakeMKV - Blu-rays, protected dvd's, and dvd with mainfeature off
     if rip_with_mkv(job, protection):
-        logging.info("------------- Ripping disc with MakeMKV -------------")
+        logging.info("************* Ripping disc with MakeMKV *************")
         # Run MakeMKV and get path to output
         job.status = "ripping"
         db.session.commit()
@@ -63,7 +63,7 @@ def rip_visual_media(have_dupes, job, logfile, protection):
             sys.exit()
         if job.config.NOTIFY_RIP:
             utils.notify(job, constants.NOTIFY_TITLE, f"{job.title} rip complete. Starting transcode. ")
-        logging.info("------------- Ripping with MakeMKV completed -------------")
+        logging.info("************* Ripping with MakeMKV completed *************")
         # point HB to the path MakeMKV ripped to
         hb_in_path = makemkv_out_path
     # Begin transcoding section - only transcode if skip_transcode is false
@@ -81,7 +81,7 @@ def rip_visual_media(have_dupes, job, logfile, protection):
     utils.delete_raw_files(hb_in_path, hb_out_path, makemkv_out_path)
     # report errors if any
     notify_exit(job)
-    logging.info("--------------- ARM processing complete ---------------")
+    logging.info("************* ARM processing complete *************")
 
 
 def start_transcode(job, logfile, hb_in_path, hb_out_path, protection):
@@ -98,7 +98,7 @@ def start_transcode(job, logfile, hb_in_path, hb_out_path, protection):
     if not job.config.SKIP_TRANSCODE:
         # Update db with transcoding status
         utils.database_updater({'status': "transcoding"}, job)
-        logging.info("------------- Starting Transcode With HandBrake -------------")
+        logging.info("************* Starting Transcode With HandBrake *************")
         if rip_with_mkv(job, protection):
             handbrake.handbrake_mkv(hb_in_path, hb_out_path, logfile, job)
         elif job.video_type == "movie" and job.config.MAINFEATURE and job.hasnicetitle:
@@ -107,7 +107,7 @@ def start_transcode(job, logfile, hb_in_path, hb_out_path, protection):
         else:
             handbrake.handbrake_all(hb_in_path, hb_out_path, logfile, job)
             job.eject()
-        logging.info("------------- Finished Transcode With HandBrake -------------")
+        logging.info("************* Finished Transcode With HandBrake *************")
 
 
 def notify_exit(job):
@@ -194,7 +194,7 @@ def skip_transcode_movie(files, job, raw_path):
     logging.debug(f"Largest file is: {largest_file_name}")
     temp_path = os.path.join(raw_path, largest_file_name)
     if os.stat(temp_path).st_size <= 1:  # sanity check for filesize
-        logging.debug(f"{raw_path} is empty or very small size. - Folder size: {os.stat(temp_path).st_size}")
+        logging.info(f"{raw_path} is empty or very small size. - Folder size: {os.stat(temp_path).st_size}")
     for file in files:
         # move main into main folder
         # move others into extras folder
@@ -204,7 +204,7 @@ def skip_transcode_movie(files, job, raw_path):
         else:
             # If mainfeature is enabled - skip to the next file
             if job.config.MAINFEATURE:
-                logging.debug(f"MAINFEATURE IS {job.config.MAINFEATURE} - Skipping move of {file}")
+                logging.info(f"MAINFEATURE IS {job.config.MAINFEATURE} - Skipping move of {file}")
                 continue
             # Other/extras
             if str(job.config.EXTRAS_SUB).lower() != "none":

--- a/arm/ripper/arm_ripper.py
+++ b/arm/ripper/arm_ripper.py
@@ -7,8 +7,8 @@ import logging
 
 sys.path.append("/opt/arm")
 
-from arm.ripper import utils, makemkv, handbrake # noqa E402
-from arm.ui import app, db, constants # noqa E402
+from arm.ripper import utils, makemkv, handbrake  # noqa E402
+from arm.ui import app, db, constants  # noqa E402
 
 
 def rip_visual_media(have_dupes, job, logfile, protection):

--- a/arm/ripper/arm_ripper.py
+++ b/arm/ripper/arm_ripper.py
@@ -1,3 +1,213 @@
 """ Main file for running DVDs/Blu-rays/CDs/data ?
 It would help clear up main and make things easier to find
 """
+import sys
+import os
+import logging
+
+sys.path.append("/opt/arm")
+
+from arm.ripper import utils, makemkv, handbrake
+from arm.ui import app, db, constants # noqa E402
+
+
+def rip_visual_media(have_dupes, job, logfile, protection):
+    """
+    Main ripping function for dvd and Blu-rays, movies or series
+    \n
+    :param have_dupes: Does this disc already exist in the database
+    :param job: Current job
+    :param logfile: Current logfile
+    :param protection: Does the disc have 99 track protection
+    :return: None
+    """
+    # Fix the sub-folder type - (movie|tv|unknown)
+    type_sub_folder = utils.convert_job_type(job.video_type)
+    # Fix the job title - Title (Year) | Title
+    job_title = utils.fix_job_title(job)
+
+    # We need to check/construct the final path, and the transcode path
+    hb_out_path = os.path.join(job.config.TRANSCODE_PATH, type_sub_folder, job_title)
+    final_directory = os.path.join(job.config.COMPLETED_PATH, type_sub_folder, job_title)
+
+    # Check folders for already ripped jobs -> creates folder
+    hb_out_path = utils.check_for_dupe_folder(have_dupes, hb_out_path, job)
+    # If dupes rips is disabled this might kill the run
+    final_directory = utils.check_for_dupe_folder(have_dupes, final_directory, job)
+
+    # Update the job.path with the final directory
+    utils.database_updater({'path': final_directory}, job)
+    # Save poster image from disc if enabled
+    utils.save_disc_poster(final_directory, job)
+
+    logging.info(f"Processing files to: {hb_out_path}")
+    makemkv_out_path = None
+    hb_in_path = str(job.devpath)
+    # Do we need to use MakeMKV - Blu-rays, protected dvd's, and dvd with mainfeature off
+    if rip_with_mkv(job, protection):
+        logging.info("------------- Ripping disc with MakeMKV -------------")
+        # Run MakeMKV and get path to output
+        job.status = "ripping"
+        db.session.commit()
+        try:
+            makemkv_out_path = makemkv.makemkv(logfile, job)
+        except Exception as mkv_error:  # noqa: E722
+            logging.error(f"MakeMKV did not complete successfully.  Exiting ARM! "
+                          f"Error: {mkv_error}")
+            raise ValueError from mkv_error
+
+        if makemkv_out_path is None:
+            logging.error("MakeMKV did not complete successfully.  Exiting ARM!")
+            job.status = "fail"
+            db.session.commit()
+            sys.exit()
+        if job.config.NOTIFY_RIP:
+            utils.notify(job, constants.NOTIFY_TITLE, f"{job.title} rip complete. Starting transcode. ")
+        logging.info("------------- Ripping with MakeMKV completed -------------")
+        # point HB to the path MakeMKV ripped to
+        hb_in_path = makemkv_out_path
+    # Begin transcoding section - only transcode if skip_transcode is false
+    start_transcode(job, logfile, hb_in_path, hb_out_path, protection)
+    # --------------- POST PROCESSING ---------------
+    # Move to final folder
+    move_files_post(hb_out_path, job)
+    # Movie the movie poster if we have one - no longer needed, now handled by save_movie_poster
+    utils.move_movie_poster(final_directory, hb_out_path)
+    # Scan emby if arm.yaml requires it
+    utils.scan_emby()
+    # Set permissions if arm.yaml requires it
+    utils.set_permissions(final_directory)
+    # If set in the arm.yaml remove the raw files
+    utils.delete_raw_files(hb_in_path, hb_out_path, makemkv_out_path)
+    # report errors if any
+    notify_exit(job)
+    logging.info("--------------- ARM processing complete ---------------")
+
+
+def start_transcode(job, logfile, hb_in_path, hb_out_path, protection):
+    """
+    This check if transcoding is enabled for the job and then passes it off to the correct
+    handbrake function\n
+    :param hb_in_path: HandBrake in path (makeMKV_out_path|/dev/sr0)
+    :param hb_out_path: Path HandBrake should put the files (transcode_path)
+    :param job: Current job
+    :param logfile: Current logfile
+    :param protection: If disc has 99 track protection
+    :return: None
+    """
+    if not job.config.SKIP_TRANSCODE:
+        # Update db with transcoding status
+        utils.database_updater({'status': "transcoding"}, job)
+        logging.info("------------- Starting Transcode With HandBrake -------------")
+        if rip_with_mkv(job, protection):
+            handbrake.handbrake_mkv(hb_in_path, hb_out_path, logfile, job)
+        elif job.video_type == "movie" and job.config.MAINFEATURE and job.hasnicetitle:
+            handbrake.handbrake_main_feature(hb_in_path, hb_out_path, logfile, job)
+            job.eject()
+        else:
+            handbrake.handbrake_all(hb_in_path, hb_out_path, logfile, job)
+            job.eject()
+        logging.info("------------- Finished Transcode With HandBrake -------------")
+
+
+def notify_exit(job):
+    """
+    Notify post transcoding - ARM finished\n
+    Includes any errors
+    :param job: current job
+    :return: None
+    """
+    if job.config.NOTIFY_TRANSCODE:
+        if job.errors:
+            errlist = ', '.join(job.errors)
+            utils.notify(job, constants.NOTIFY_TITLE,
+                         f" {job.title} processing completed with errors. "
+                         f"Title(s) {errlist} failed to complete. ")
+            logging.info(f"Transcoding completed with errors.  Title(s) {errlist} failed to complete. ")
+        else:
+            utils.notify(job, constants.NOTIFY_TITLE, str(job.title) + constants.PROCESS_COMPLETE)
+
+
+def move_files_post(hb_out_path, job):
+    """
+    Logic for moving files post transcoding\n
+    if series move all to 1 folder\n
+    if movie check what source we got them from, for MakeMKV use skip_transcode_movie, so we can check filesize\n
+    :param hb_out_path: current files' directory
+    :param job: current job
+    :return: None
+    """
+    tracks = job.tracks.filter_by(ripped=True)  # .order_by(job.tracks.length.desc())
+    if job.video_type == "series":
+        for track in tracks:
+            utils.move_files(hb_out_path, track.filename, job, True)
+    else:
+        for track in tracks:
+            if tracks.count() == 1:
+                utils.move_files(hb_out_path, track.filename, job, True)
+            else:
+                # If source is MakeMKV we know the mainfeature will be wrong let skip_transcode_movie handle it
+                if track.source == "MakeMKV":
+                    skip_transcode_movie(os.listdir(hb_out_path), job, hb_out_path)
+                    break
+                # If HandBrake was used we can pass track.main_feature
+                utils.move_files(hb_out_path, track.filename, job, track.main_feature)
+
+
+def rip_with_mkv(current_job, protection=0):
+    """
+    Test to check if title was or should be ripped by MakeMKV\n
+    :param current_job: current job
+    :param protection: If the disc have 99 track protection
+    :return: Bool
+    """
+    mkv_ripped = False
+    # Rip bluray
+    if current_job.disctype == "bluray" and current_job.config.RIPMETHOD == "mkv":
+        mkv_ripped = True
+    # Rip dvd with mode: mkv and mainfeature: false
+    if current_job.disctype == "dvd" and (not current_job.config.MAINFEATURE and current_job.config.RIPMETHOD == "mkv"):
+        mkv_ripped = True
+    # If dvd has 99 protection force MakeMKV to be used
+    if protection:
+        mkv_ripped = True
+    return mkv_ripped
+
+
+def skip_transcode_movie(files, job, raw_path):
+    """
+    Only ran if job is a movie - find the largest file use it as mainfeature\n
+    Movie everything else to extras folder\n
+    If mainfeature is enabled skip moving everything but the main file\n
+    :param files: os.listdir(RAW_PATH)
+    :param job: Current job
+    :param raw_path: RAW_PATH of ripped mkv files (mkvoutpath)
+    :return: None
+    """
+    logging.debug(f"Videotype: {job.video_type}")
+    # if video_type is movie, then move the biggest title to media_dir
+    # move the rest of the files to the extras' folder
+    # find largest filesize
+    logging.debug("Finding largest file")
+    largest_file_name = utils.find_largest_file(files, raw_path)
+    # largest_file_name should be the largest file
+    logging.debug(f"Largest file is: {largest_file_name}")
+    temp_path = os.path.join(raw_path, largest_file_name)
+    if os.stat(temp_path).st_size <= 1:  # sanity check for filesize
+        logging.debug(f"{raw_path} is empty or very small size. - Folder size: {os.stat(temp_path).st_size}")
+    for file in files:
+        # move main into main folder
+        # move others into extras folder
+        if file == largest_file_name:
+            # largest movie
+            utils.move_files(raw_path, file, job, True)
+        else:
+            # If mainfeature is enabled - skip to the next file
+            if job.config.MAINFEATURE:
+                logging.debug(f"MAINFEATURE IS {job.config.MAINFEATURE} - Skipping move of {file}")
+                continue
+            # Other/extras
+            if str(job.config.EXTRAS_SUB).lower() != "none":
+                utils.move_files(raw_path, file, job, False)
+            else:
+                logging.info(f"Not moving extra: \"{file}\" - Sub folder is not set or named incorrectly")

--- a/arm/ripper/arm_ripper.py
+++ b/arm/ripper/arm_ripper.py
@@ -7,7 +7,7 @@ import logging
 
 sys.path.append("/opt/arm")
 
-from arm.ripper import utils, makemkv, handbrake
+from arm.ripper import utils, makemkv, handbrake # noqa E402
 from arm.ui import app, db, constants # noqa E402
 
 

--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -112,7 +112,6 @@ def identify_dvd(job):
         dvd_title = f"{job.label}_{crc64}"
         logging.info(f"DVD CRC64 hash is: {crc64}")
         job.crc_id = str(crc64)
-        # TODO there was a bug with this db - we need to fix it by looking up the imdb of the result
         urlstring = f"https://1337server.pythonanywhere.com/api/v1/?mode=s&crc64={crc64}"
         logging.debug(urlstring)
         dvd_info_xml = urllib.request.urlopen(urlstring).read()

--- a/arm/ripper/logger.py
+++ b/arm/ripper/logger.py
@@ -66,7 +66,8 @@ def clean_loggers():
 
 def clean_up_logs(logpath, loglife):
     """
-    Delete all log files older than x days\n
+    Delete all log files older than {loglife} days\n
+    if {loglife} is 0 don't delete anything\n
     :param logpath: path of log files\n
     :param loglife: days to let logs live\n
     :return:

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -145,7 +145,7 @@ if __name__ == "__main__":
     # Sometimes drives trigger twice this stops multi runs from 1 udev trigger
     utils.duplicate_run_check(devpath)
 
-    logging.info(f"------------- Starting ARM processing at {datetime.datetime.now()} -------------")
+    logging.info(f"************* Starting ARM processing at {datetime.datetime.now()} *************")
     if args.protection:
         logging.warning("Found 99 Track protection system - Job may fail!")
     # put in job
@@ -184,6 +184,7 @@ if __name__ == "__main__":
         job.status = "fail"
         job.errors = str(error)
         job.eject()
+        # Possibly add cleanup section here for failed job files
     else:
         job.status = "success"
     finally:

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -27,7 +27,6 @@ def entry():
     parser = argparse.ArgumentParser(description='Process disc using ARM')
     parser.add_argument('-d', '--devpath', help='Devpath', required=True)
     parser.add_argument('-p', '--protection', help='Does disc have 99 track protection', required=False)
-    print(parser.parse_args())
     return parser.parse_args()
 
 

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -11,13 +11,12 @@ import logging  # noqa: E402
 import time  # noqa: E402
 import datetime  # noqa: E402
 import re  # noqa: E402
-import shutil  # noqa: E402
 import getpass  # noqa E402
 import pyudev  # noqa: E402
 
 sys.path.append("/opt/arm")
 
-from arm.ripper import logger, utils, makemkv, handbrake, identify, arm_ripper  # noqa: E402
+from arm.ripper import logger, utils, identify, arm_ripper  # noqa: E402
 from arm.config.config import cfg  # noqa: E402
 from arm.models.models import Job, Config  # noqa: E402
 from arm.ui import app, db, constants  # noqa E402

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -17,20 +17,18 @@ import pyudev  # noqa: E402
 
 sys.path.append("/opt/arm")
 
-from arm.ripper import logger, utils, makemkv, handbrake, identify  # noqa: E402
+from arm.ripper import logger, utils, makemkv, handbrake, identify, arm_ripper  # noqa: E402
 from arm.config.config import cfg  # noqa: E402
 from arm.models.models import Job, Config  # noqa: E402
-from arm.ui import app, db  # noqa E402
-
-NOTIFY_TITLE = "ARM notification"
-PROCESS_COMPLETE = " processing complete. "
+from arm.ui import app, db, constants  # noqa E402
 
 
 def entry():
     """ Entry to program, parses arguments"""
     parser = argparse.ArgumentParser(description='Process disc using ARM')
     parser.add_argument('-d', '--devpath', help='Devpath', required=True)
-
+    parser.add_argument('-p', '--protection', help='Does disc have 99 track protection', required=False)
+    print(parser.parse_args())
     return parser.parse_args()
 
 
@@ -83,84 +81,12 @@ def check_fstab():
     logging.error("No fstab entry found.  ARM will likely fail.")
 
 
-def skip_transcode(job, final_directory, raw_path, hb_out_path):
-    """
-    Section to follow when Skip transcoding is enabled exit when finished
-    :param job: current Job
-    :param final_directory: final directory
-    :param raw_path: RAW_PATH
-    :return: sys.exit()
-    """
-    logging.info("SKIP_TRANSCODE is true.  Moving raw mkv files.")
-    logging.info("NOTE: Identified main feature may not be actual main feature")
-    files = os.listdir(raw_path)
-
-    if job.video_type == "movie":
-        skip_transcode_movie(files, job, raw_path)
-    else:
-        # if video_type is not movie, then move everything
-        logging.debug(f"Video type: {job.video_type}")
-        for file in files:
-            utils.move_files(raw_path, file, job, True)
-
-    # remove raw files, if specified in config
-    if cfg["DELRAWFILES"]:
-        logging.info("Removing raw files")
-        shutil.rmtree(raw_path)
-        shutil.rmtree(hb_out_path)
-
-    utils.set_permissions(final_directory)
-    utils.notify(job, NOTIFY_TITLE, str(job.title) + PROCESS_COMPLETE)
-
-    logging.info("ARM processing complete")
-    utils.database_updater({'status': "success"}, job)
-    job.eject()
-    sys.exit()
-
-
-def skip_transcode_movie(files, job, raw_path):
-    """
-    only ran if job is a movie find the largest file use it as mainfeature\n\n
-    :param files: os.listdir(RAW_PATH)
-    :param job: Current job
-    :param raw_path: RAW_PATH of ripped mkv files (mkvoutpath)
-    :return: None
-    """
-    logging.debug(f"Videotype: {job.video_type}")
-    # if video_type is movie, then move the biggest title to media_dir
-    # move the rest of the files to the extras' folder
-    # find largest filesize
-    logging.debug("Finding largest file")
-    largest_file_name = utils.find_largest_file(files, raw_path)
-    # largest_file_name should be the largest file
-    logging.debug(f"Largest file is: {largest_file_name}")
-    temp_path = os.path.join(raw_path, largest_file_name)
-    if os.stat(temp_path).st_size <= 1:  # sanity check for filesize
-        logging.debug(f"{raw_path} is empty or very small size. - Folder size: {os.stat(temp_path).st_size}")
-    for file in files:
-        # move main into main folder
-        # move others into extras folder
-        if file == largest_file_name:
-            # largest movie
-            utils.move_files(raw_path, file, job, True)
-        else:
-            # If mainfeature is enabled skip to the next file
-            if job.config.MAINFEATURE:
-                logging.debug(f"MAINFEATURE IS {job.config.MAINFEATURE} - Skipping move of {file}")
-                continue
-            # Other/extras
-            if str(cfg["EXTRAS_SUB"]).lower() != "none":
-                utils.move_files(raw_path, file, job, False)
-            else:
-                logging.info(f"Not moving extra: \"{file}\" - Sub folder is not set or named incorrectly")
-
-
-def main(logfile, job):
+def main(logfile, job, protection=0):
     """main disc processing function"""
     logging.info("Starting Disc identification")
     identify.identify(job)
     # Check db for entries matching the crc and successful
-    have_dupes, crc_jobs = utils.job_dupe_check(job)
+    have_dupes = utils.job_dupe_check(job)
     logging.debug(f"Value of have_dupes: {have_dupes}")
 
     utils.notify_entry(job)
@@ -173,111 +99,10 @@ def main(logfile, job):
     utils.database_updater({'stage': str(round(time.time() * 100))}, job)
     # Entry point for dvd/bluray
     if job.disctype in ["dvd", "bluray"]:
-        type_sub_folder = utils.convert_job_type(job.video_type)
-        # We need to check/construct the final path, and the transcode path
-        if job.year and job.year != "0000" and job.year != "":
-            hb_out_path = os.path.join(cfg["TRANSCODE_PATH"], str(type_sub_folder), f"{job.title} ({job.year})")
-            final_directory = os.path.join(cfg["COMPLETED_PATH"], str(type_sub_folder), f"{job.title} ({job.year})")
-        else:
-            hb_out_path = os.path.join(cfg["TRANSCODE_PATH"], str(type_sub_folder), str(job.title))
-            final_directory = os.path.join(cfg["COMPLETED_PATH"], str(type_sub_folder), str(job.title))
-        # Check folders for already ripped jobs -> creates folder
-        hb_out_path = utils.check_for_dupe_folder(have_dupes, hb_out_path, job)
-        # If dupes rips is disabled this might kill the run
-        final_directory = utils.check_for_dupe_folder(have_dupes, final_directory, job)
-        # Update the job.path with the final directory
-        utils.database_updater({'path': final_directory}, job)
-        # Save poster image from disc if enabled
-        utils.save_disc_poster(final_directory, job)
-
-        logging.info(f"Processing files to: {hb_out_path}")
-        mkvoutpath = None
-        hb_in_path = str(job.devpath)
-        # entry point for bluray
-        #  or dvd with (not MAINFEATURE and RIPMETHOD mkv)
-        if job.disctype == "bluray" or (not cfg["MAINFEATURE"] and cfg["RIPMETHOD"] == "mkv"):
-            # Run MakeMKV and get path to output
-            job.status = "ripping"
-            db.session.commit()
-            try:
-                mkvoutpath = makemkv.makemkv(logfile, job)
-            except Exception as mkv_error:  # noqa: E722
-                logging.error(f"MakeMKV did not complete successfully.  Exiting ARM! "
-                              f"Error: {mkv_error}")
-                raise
-
-            if mkvoutpath is None:
-                logging.error("MakeMKV did not complete successfully.  Exiting ARM!")
-                job.status = "fail"
-                db.session.commit()
-                sys.exit()
-            if cfg["NOTIFY_RIP"]:
-                utils.notify(job, NOTIFY_TITLE, f"{job.title} rip complete. Starting transcode. ")
-
-            # Entry point for not transcoding
-            if cfg["SKIP_TRANSCODE"] and cfg["RIPMETHOD"] == "mkv":
-                skip_transcode(job, final_directory, mkvoutpath, hb_out_path)
-            # point HB to the path MakeMKV ripped to
-            hb_in_path = mkvoutpath
-
-        # Update db with transcoding status
-        utils.database_updater({'status': "transcoding"}, job)
-        # Begin transcoding section
-        if job.disctype == "bluray" and cfg["RIPMETHOD"] == "mkv" \
-                or job.disctype == "dvd" and (not cfg["MAINFEATURE"] and cfg["RIPMETHOD"] == "mkv"):
-            handbrake.handbrake_mkv(hb_in_path, hb_out_path, logfile, job)
-        elif job.video_type == "movie" and cfg["MAINFEATURE"] and job.hasnicetitle:
-            handbrake.handbrake_main_feature(hb_in_path, hb_out_path, logfile, job)
-            job.eject()
-        else:
-            handbrake.handbrake_all(hb_in_path, hb_out_path, logfile, job)
-            job.eject()
-
-        # check if there is a new title and change all filenames
-        db.session.refresh(job)
-        logging.debug(f"New Title is {job.title}")
-
-        # Move to final folder
-        tracks = job.tracks.filter_by(ripped=True)  # .order_by(job.tracks.length.desc())
-        if job.video_type == "series":
-            for track in tracks:
-                utils.move_files(hb_out_path, track.filename, job, True)
-        else:
-            for track in tracks:
-                if tracks.count() == 1:
-                    utils.move_files(hb_out_path, track.filename, job, True)
-                else:
-                    # If source is MakeMKV we know the mainfeature will be wrong let skip_transcode_movie handle it
-                    if track.source == "MakeMKV":
-                        skip_transcode_movie(os.listdir(hb_out_path), job, hb_out_path)
-                        break
-                    # If HandBrake was used we can pass track.main_feature
-                    utils.move_files(hb_out_path, track.filename, job, track.main_feature)
-
-        # Movie the movie poster if we have one
-        utils.move_movie_poster(final_directory, hb_out_path)
-        # Scan emby if arm.yaml requires it
-        utils.scan_emby()
-        # Set permissions if arm.yaml requires it
-        utils.set_permissions(final_directory)
-        # If set in the arm.yaml remove the raw files
-        utils.delete_raw_files(hb_in_path, hb_out_path, mkvoutpath)
-        # report errors if any
-        if cfg["NOTIFY_TRANSCODE"]:
-            if job.errors:
-                errlist = ', '.join(job.errors)
-                utils.notify(job, NOTIFY_TITLE,
-                             f" {job.title} processing completed with errors. "
-                             f"Title(s) {errlist} failed to complete. ")
-                logging.info(f"Transcoding completed with errors.  Title(s) {errlist} failed to complete. ")
-            else:
-                utils.notify(job, NOTIFY_TITLE, str(job.title) + PROCESS_COMPLETE)
-
-        logging.info("ARM processing complete")
-
+        arm_ripper.rip_visual_media(have_dupes, job, logfile, protection)
     elif job.disctype == "music":
         if utils.rip_music(job, logfile):
-            utils.notify(job, NOTIFY_TITLE, f"Music CD: {job.label} {PROCESS_COMPLETE}")
+            utils.notify(job, constants.NOTIFY_TITLE, f"Music CD: {job.label} {constants.PROCESS_COMPLETE}")
             utils.scan_emby()
             # This shouldn't be needed. but to be safe
             job.status = "success"
@@ -291,7 +116,7 @@ def main(logfile, job):
     elif job.disctype == "data":
         logging.info("Disc identified as data")
         if utils.rip_data(job):
-            utils.notify(job, NOTIFY_TITLE, f"Data disc: {job.label} copying complete. ")
+            utils.notify(job, constants.NOTIFY_TITLE, f"Data disc: {job.label} copying complete. ")
         else:
             logging.info("Data rip failed.  See previous errors.  Exiting.")
         job.eject()
@@ -303,29 +128,33 @@ def main(logfile, job):
 if __name__ == "__main__":
     # Make sure all directories are fully setup
     utils.arm_setup()
+    # Get arguments from arg parser
     args = entry()
-    devpath = "/dev/" + args.devpath
+    devpath = f"/dev/{args.devpath}"
+    # Create new job
     job = Job(devpath)
-    logfile = logger.setup_logging(job)
+    # Setup logging
+    log_file = logger.setup_logging(job)
     # Exit if drive isn't ready
     if utils.get_cdrom_status(devpath) != 4:
         logging.info("Drive appears to be empty or is not ready.  Exiting ARM.")
         sys.exit()
     # Don't put out anything if we are using the empty.log NAS_[0-9].log or NAS1_[0-9].log
-    if logfile.find("empty.log") != -1 or re.search(r"(NAS|NAS1)_\d+\.log", logfile) is not None:
+    if log_file.find("empty.log") != -1 or re.search(r"(NAS|NAS1)_\d+\.log", log_file) is not None:
         sys.exit()
     # Check the db is current, if not update it
     utils.check_db_version(cfg['INSTALLPATH'], cfg['DBFILE'])
     # Sometimes drives trigger twice this stops multi runs from 1 udev trigger
     utils.duplicate_run_check(devpath)
 
-    logging.info(f"Starting ARM processing at {datetime.datetime.now()}")
-
-    # put in db
+    logging.info(f"------------- Starting ARM processing at {datetime.datetime.now()} -------------")
+    if args.protection:
+        logging.warning("Found 99 Track protection system - Job may fail!")
+    # put in job
     job.status = "active"
     job.start_time = datetime.datetime.now()
     utils.database_adder(job)
-
+    # Sleep to slow down chances of db locked - unlikely to be needed
     time.sleep(1)
     # Add the job.config to db
     config = Config(cfg, job_id=job.job_id)
@@ -334,6 +163,7 @@ if __name__ == "__main__":
     # Log version number
     with open(os.path.join(cfg["INSTALLPATH"], 'VERSION')) as version_file:
         version = version_file.read().strip()
+    # Add the git commit number to logging
     utils.get_git_commit()
     logging.info(f"ARM version: {version}")
     job.arm_version = version
@@ -344,14 +174,15 @@ if __name__ == "__main__":
     logging.info(f"Job: {job.label}")  # This will sometimes be none
     # Check for zombie jobs and update status to failed
     utils.clean_old_jobs()
+    # Log all params/attribs from the drive
     log_udev_params(devpath)
 
     try:
-        main(logfile, job)
+        main(log_file, job, args.protection)
     except Exception as error:
-        logging.exception("A fatal error has occurred and ARM is exiting.  See traceback below for details.")
-        utils.notify(job, NOTIFY_TITLE, "ARM encountered a fatal error processing "
-                                        f"{job.title}. Check the logs for more details. {error}")
+        logging.error("A fatal error has occurred and ARM is exiting.  See traceback below for details.")
+        utils.notify(job, constants.NOTIFY_TITLE, "ARM encountered a fatal error processing "
+                                                  f"{job.title}. Check the logs for more details. {error}")
         job.status = "fail"
         job.errors = str(error)
         job.eject()

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -8,7 +8,6 @@ import logging
 import subprocess
 import shlex
 
-from arm.config.config import cfg
 from arm.ripper import utils  # noqa: E402
 from arm.ui import db  # noqa: F401, E402
 
@@ -37,7 +36,7 @@ def makemkv(logfile, job):
 
     # confirm MKV is working, beta key hasn't expired
     prep_mkv(job)
-    logging.info(f"Starting MakeMKV rip. Method is {cfg['RIPMETHOD']}")
+    logging.info(f"Starting MakeMKV rip. Method is {job.config.RIPMETHOD}")
     # get MakeMKV disc number
     logging.debug("Getting MakeMKV disc number")
     cmd = f"makemkvcon -r info disc:9999  |grep {job.devpath} |grep -oP '(?<=:).*?(?=,)'"
@@ -51,23 +50,23 @@ def makemkv(logfile, job):
         raise MakeMkvRuntimeError(mdisc_error)
 
     # get filesystem in order
-    rawpath = setup_rawpath(job, os.path.join(str(cfg["RAW_PATH"]), str(job.title)))
-
+    rawpath = setup_rawpath(job, os.path.join(str(job.config.RAW_PATH), str(job.title)))
+    logging.info(f"Processing files to: {rawpath}")
     # Rip bluray
-    if cfg["RIPMETHOD"] == "backup" and job.disctype == "bluray":
+    if job.config.RIPMETHOD == "backup" and job.disctype == "bluray":
         # backup method
-        cmd = f'makemkvcon backup --minlength={cfg["MINLENGTH"]} --decrypt {cfg["MKV_ARGS"]} ' \
+        cmd = f'makemkvcon backup --minlength={job.config.MINLENGTH} --decrypt {job.config.MKV_ARGS} ' \
               f'-r disc:{mdisc.strip()} {shlex.quote(rawpath)}>> {logfile}'
         logging.info("Backup up disc")
         run_makemkv(cmd)
     # Rip DVD
-    elif cfg["RIPMETHOD"] == "mkv" or job.disctype == "dvd":
+    elif job.config.RIPMETHOD == "mkv" or job.disctype == "dvd":
         get_track_info(mdisc, job)
 
         # if no maximum length, process the whole disc in one command
-        if int(cfg["MAXLENGTH"]) > 99998:
-            cmd = f'makemkvcon mkv {cfg["MKV_ARGS"]} -r --progress=-stdout --messages=-stdout ' \
-                  f'dev:{job.devpath} all {shlex.quote(rawpath)} --minlength={cfg["MINLENGTH"]}>> {logfile}'
+        if int(job.config.MAXLENGTH) > 99998:
+            cmd = f'makemkvcon mkv {job.config.MKV_ARGS} -r --progress=-stdout --messages=-stdout ' \
+                  f'dev:{job.devpath} all {shlex.quote(rawpath)} --minlength={job.config.MINLENGTH}>> {logfile}'
             run_makemkv(cmd)
         else:
             process_single_tracks(job, logfile, rawpath)
@@ -89,14 +88,14 @@ def process_single_tracks(job, logfile, rawpath):
     """
     # process one track at a time based on track length
     for track in job.tracks:
-        if track.length < int(cfg["MINLENGTH"]):
+        if track.length < int(job.config.MINLENGTH):
             # too short
             logging.info(f"Track #{track.track_number} of {job.no_of_titles}. Length ({track.length}) "
-                         f"is less than minimum length ({cfg['MINLENGTH']}).  Skipping")
-        elif track.length > int(cfg["MAXLENGTH"]):
+                         f"is less than minimum length ({job.config.MINLENGTH}).  Skipping")
+        elif track.length > int(job.config.MAXLENGTH):
             # too long
             logging.info(f"Track #{track.track_number} of {job.no_of_titles}. "
-                         f"Length ({track.length}) is greater than maximum length ({cfg['MAXLENGTH']}).  "
+                         f"Length ({track.length}) is greater than maximum length ({job.config.MAXLENGTH}).  "
                          "Skipping")
         else:
             # just right
@@ -105,9 +104,9 @@ def process_single_tracks(job, logfile, rawpath):
             filepathname = os.path.join(rawpath, track.filename)
             logging.info(f"Ripping title {track.track_number} to {shlex.quote(filepathname)}")
 
-            cmd = f'makemkvcon mkv {cfg["MKV_ARGS"]} -r --progress=-stdout --messages=-stdout' \
+            cmd = f'makemkvcon mkv {job.config.MKV_ARGS} -r --progress=-stdout --messages=-stdout' \
                   f'dev:{job.devpath} {track.track_number} {shlex.quote(rawpath)} ' \
-                  f'--minlength={cfg["MINLENGTH"]}>> {logfile}'
+                  f'--minlength={job.config.MINLENGTH}>> {logfile}'
             # Possibly update db to say track was ripped
             run_makemkv(cmd)
 
@@ -130,7 +129,7 @@ def setup_rawpath(job, raw_path):
     else:
         logging.info(f"{raw_path} exists.  Adding timestamp.")
         random_time = job.stage
-        raw_path = os.path.join(str(cfg["RAW_PATH"]), f"{job.title}_{random_time}")
+        raw_path = os.path.join(str(job.config.RAW_PATH), f"{job.title}_{random_time}")
         logging.info(f"raw_path is {raw_path}")
         try:
             os.makedirs(raw_path)
@@ -202,7 +201,7 @@ def get_track_info(mdisc, job):
 
     logging.info("Using MakeMKV to get information on all the tracks on the disc. This will take a few minutes...")
 
-    cmd = f'makemkvcon -r --progress=-stdout --messages=-stdout --minlength={cfg["MINLENGTH"]} ' \
+    cmd = f'makemkvcon -r --progress=-stdout --messages=-stdout --minlength={job.config.MINLENGTH} ' \
           f'--cache=1 info disc:{mdisc}'
     logging.debug(f"Sending command: {cmd}")
     try:

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -74,9 +74,9 @@ def notify_entry(job):
     if job.disctype in ["dvd", "bluray"]:
         # Send the notifications
         notify(job, NOTIFY_TITLE,
-               f"Found disc: {job.title}. Disc type is {job.disctype}. Main Feature is {cfg['MAINFEATURE']}"
+               f"Found disc: {job.title}. Disc type is {job.disctype}. Main Feature is {job.config.MAINFEATURE}"
                f".  Edit entry here: http://{check_ip()}:"
-               f"{cfg['WEBSERVER_PORT']}/jobdetail?job_id={job.job_id}")
+               f"{job.config.WEBSERVER_PORT}/jobdetail?job_id={job.job_id}")
     elif job.disctype == "music":
         notify(job, NOTIFY_TITLE, f"Found music CD: {job.label}. Ripping all tracks")
     elif job.disctype == "data":
@@ -90,7 +90,7 @@ def notify_entry(job):
 
 def sleep_check_process(process_str, transcode_limit):
     """
-    New function to check for max_transcode from cfg file and force obey limits\n
+    New function to check for max_transcode from job.config and force obey limits\n
     :param str process_str: The process string from arm.yaml
     :param int transcode_limit: The user defined limit for maximum transcodes
     :return bool: when we have space in the transcode queue
@@ -117,7 +117,7 @@ def sleep_check_process(process_str, transcode_limit):
 
 def convert_job_type(video_type):
     """
-    Converts the job_type to the correct folder
+    Converts the job_type to the correct sub-folder
     :param video_type: job.video_type
     :return: string of the correct folder
     """
@@ -162,12 +162,12 @@ def move_files(base_path, filename, job, is_main_feature=False):
         return None
     movie_path = job.path
     logging.info(f"Moving {job.video_type} {filename} to {movie_path}")
-    # For series there are no extras so always use the base path
-    extras_path = os.path.join(movie_path, cfg["EXTRAS_SUB"]) if job.video_type != "series" else movie_path
+    # For series there are no extras so always use the base path - not needed, but extra safe
+    extras_path = os.path.join(movie_path, job.config.EXTRAS_SUB) if job.video_type != "series" else movie_path
     make_dir(movie_path)
 
     if is_main_feature:
-        movie_file = os.path.join(movie_path, video_title + "." + cfg["DEST_EXT"])
+        movie_file = os.path.join(movie_path, video_title + "." + job.config.DEST_EXT)
         logging.info(f"Track is the Main Title.  Moving '{os.path.join(base_path, filename)}' to {movie_file}")
         move_files_main(os.path.join(base_path, filename), movie_file, movie_path)
     else:
@@ -197,7 +197,9 @@ def move_files_main(old_file, new_file, base_path):
 
 
 def move_movie_poster(final_directory, hb_out_path):
-    """move movie poster"""
+    """move movie poster\n
+    ---------\n
+    DEPRECIATED - Arm already builds the final path so moving is no longer needed"""
     src_poster = os.path.join(hb_out_path, "poster.png")
     dst_poster = os.path.join(final_directory, "poster.png")
     if os.path.isfile(src_poster):
@@ -337,9 +339,9 @@ def rip_music(job, logfile):
         logging.info("Disc identified as music")
         # If user has set a cfg file with ARM use it
         if os.path.isfile(abcfile):
-            cmd = f'abcde -d "{job.devpath}" -c {abcfile} >> "{os.path.join(cfg["LOGPATH"], logfile)}" 2>&1'
+            cmd = f'abcde -d "{job.devpath}" -c {abcfile} >> "{os.path.join(job.config.LOGPATH, logfile)}" 2>&1'
         else:
-            cmd = f'abcde -d "{job.devpath}" >> "{os.path.join(cfg["LOGPATH"], logfile)}" 2>&1'
+            cmd = f'abcde -d "{job.devpath}" >> "{os.path.join(job.config.LOGPATH, logfile)}" 2>&1'
 
         logging.debug(f"Sending command: {cmd}")
 
@@ -366,13 +368,13 @@ def rip_data(job):
     if job.label == "" or job.label is None:
         job.label = "data-disc"
     # get filesystem in order
-    raw_path = os.path.join(cfg["RAW_PATH"], str(job.label))
-    final_path = os.path.join(cfg["COMPLETED_PATH"], convert_job_type(job.video_type))
+    raw_path = os.path.join(job.config.RAW_PATH, str(job.label))
+    final_path = os.path.join(job.config.COMPLETED_PATH, convert_job_type(job.video_type))
     final_file_name = str(job.label)
 
     if (make_dir(raw_path)) is False:
         random_time = str(round(time.time() * 100))
-        raw_path = os.path.join(cfg["RAW_PATH"], str(job.label) + "_" + random_time)
+        raw_path = os.path.join(job.config.RAW_PATH, str(job.label) + "_" + random_time)
         final_file_name = f"{job.label}_{random_time}"
         if (make_dir(raw_path)) is False:
             logging.info(f"Could not create data directory: {raw_path}  Exiting ARM. ")
@@ -386,7 +388,7 @@ def rip_data(job):
     logging.info(f"Ripping data disc to: {incomplete_filename}")
     # Added from pull 366
     cmd = f'dd if="{job.devpath}" of="{incomplete_filename}" {cfg["DATA_RIP_PARAMETERS"]} 2>> ' \
-          f'{os.path.join(cfg["LOGPATH"], job.logfile)}'
+          f'{os.path.join(job.config.LOGPATH, job.logfile)}'
     logging.debug(f"Sending command: {cmd}")
     try:
         subprocess.check_output(cmd, shell=True).decode("utf-8")
@@ -413,7 +415,7 @@ def set_permissions(directory_to_traverse):
     """
 
     :param directory_to_traverse: directory to fix permissions
-    :return: Bool if fails
+    :return: False if fails
     """
     if not cfg['SET_MEDIA_PERMISSIONS']:
         return False
@@ -439,8 +441,12 @@ def set_permissions(directory_to_traverse):
 
 def check_db_version(install_path, db_file):
     """
-    Check if db exists and is up to date.
-    If it doesn't exist create it.  If it's out of date update it.
+    Check if db exists and is up-to-date.\n
+    If it doesn't exist create it.\n
+    If it's out of date update it.\n
+    :param install_path: The installation path of arm - default path is /opt/arm
+    :param db_file: full path to the db file for arm
+    :return: None
     """
     from alembic.script import ScriptDirectory
     from alembic.config import Config
@@ -506,6 +512,10 @@ def check_db_version(install_path, db_file):
 def try_add_default_user():
     """
     Added to fix missmatch from the armui and armripper\n
+    This will try to add a default user for the armui
+    with the details\n
+    Username: admin\n
+    Password: password\n
     :return: None
     """
     try:
@@ -552,13 +562,13 @@ def put_track(job, t_no, seconds, aspect, fps, mainfeature, source, filename="")
         basename=job.title,
         filename=filename
     )
-    job_track.ripped = (seconds > int(cfg['MINLENGTH']))
+    job_track.ripped = (seconds > int(job.config.MINLENGTH))
     database_adder(job_track)
 
 
 def arm_setup():
     """
-    Setup arm - make sure everything is fully setup and ready and there are no errors.
+    Setup arm - Create all the directories we need for arm to run
 
     :arguments: None
     :return: None
@@ -610,7 +620,7 @@ def database_updater(args, job, wait_time=90):
 
 def database_adder(obj_class):
     """
-    Used to stop database locked error
+    Used to stop database locked error\n
     :param obj_class: Job/Config/Track/ etc
     :return: True if success
     """
@@ -633,7 +643,7 @@ def database_adder(obj_class):
 
 def clean_old_jobs():
     """
-    Check for running jobs, update failed jobs that are no longer running\n
+    Check for running jobs - Update failed jobs that are no longer running\n
     :return: None
     """
     active_jobs = db.session.query(models.Job).filter(models.Job.status.notin_(['fail', 'success'])).all()
@@ -659,7 +669,7 @@ def job_dupe_check(job):
     :return: True/False, dict/None
     """
     if job.crc_id is None:
-        return False, None
+        return False
     logging.debug(f"trying to find jobs with crc64={job.crc_id}")
     previous_rips = models.Job.query.filter_by(crc_id=job.crc_id, status="success", hasnicetitle=True)
     results = {}
@@ -685,10 +695,10 @@ def job_dupe_check(job):
             "title": title, "year": year, "poster_url": poster_url, "hasnicetitle": hasnicetitle,
             "video_type": video_type}
         database_updater(active_rip, job)
-        return True, results
+        return True
 
     logging.debug("We have no previous rips/jobs matching this crc64")
-    return False, None
+    return False
 
 
 def check_ip():
@@ -729,8 +739,9 @@ def clean_for_filename(string):
 
 def duplicate_run_check(dev_path):
     """
-    This will kill any runs that have been triggered twice on the same device
-
+    This will kill any runs that have been triggered twice on the same device\n
+    Some drives will trigger the udev twice causing 1 disc insert to add 2 jobs\n
+    this stops that issue
     :return: None
     """
     running_jobs = db.session.query(models.Job).filter(
@@ -752,16 +763,14 @@ def save_disc_poster(final_directory, job):
     :return: None
     """
     if job.disctype == "dvd" and cfg["RIP_POSTER"]:
-        os.system("mount " + job.devpath)
+        os.system(f"mount {job.devpath}")
         if os.path.isfile(job.mountpoint + "/JACKET_P/J00___5L.MP2"):
             logging.info("Converting NTSC Poster Image")
-            os.system('ffmpeg -i "' + job.mountpoint + '/JACKET_P/J00___5L.MP2" "'
-                      + final_directory + '/poster.png"')
+            os.system(f'ffmpeg -i "{job.mountpoint}/JACKET_P/J00___5L.MP2" "{final_directory}/poster.png"')
         elif os.path.isfile(job.mountpoint + "/JACKET_P/J00___6L.MP2"):
             logging.info("Converting PAL Poster Image")
-            os.system('ffmpeg -i "' + job.mountpoint + '/JACKET_P/J00___6L.MP2" "'
-                      + final_directory + '/poster.png"')
-        os.system("umount " + job.devpath)
+            os.system(f'ffmpeg -i "{job.mountpoint}/JACKET_P/J00___6L.MP2" "{final_directory}/poster.png"')
+        os.system(f"umount {job.devpath}")
 
 
 def check_for_dupe_folder(have_dupes, hb_out_path, job):
@@ -813,11 +822,11 @@ def check_for_wait(job, config):
     :return: None
     """
     #  If we have waiting for user input enabled
-    if cfg["MANUAL_WAIT"]:
-        logging.info(f"Waiting {cfg['MANUAL_WAIT_TIME']} seconds for manual override.")
+    if job.config.MANUAL_WAIT:
+        logging.info(f"Waiting {job.config.MANUAL_WAIT_TIME} seconds for manual override.")
         database_updater({'status': "waiting"}, job)
         sleep_time = 0
-        while sleep_time < cfg["MANUAL_WAIT_TIME"]:
+        while sleep_time < job.config.MANUAL_WAIT_TIME:
             time.sleep(5)
             sleep_time += 5
             db.session.refresh(job)
@@ -843,7 +852,7 @@ def get_git_commit():
             shell=True
         ).decode("utf-8")
     except subprocess.CalledProcessError as _error:
-        logging.debug(f"Error getting git version - {_error}")
+        logging.error(f"Error getting git version - {_error}")
     git_version = re.search(r"^\* (\S+)\ncommit ([a-z\d]{5,7})", str(git_output))
     if git_version:
         logging.info(f"Branch: {git_version.group(1)} - Commit: {git_version.group(2)}")

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -286,7 +286,7 @@ def get_cdrom_status(devpath):
         disc_check = os.open(devpath, os.O_RDONLY | os.O_NONBLOCK)
     except OSError:
         # Sometimes ARM will log errors opening hard drives. this check should stop it
-        if not re.search(r'hd[a-j]|sd[a-j]|loop[0-9]', devpath):
+        if not re.search(r'hd[a-j]|sd[a-j]|loop\d', devpath):
             logging.info(f"Failed to open device {devpath} to check status.")
         sys.exit(2)
     result = fcntl.ioctl(disc_check, 0x5326, 0)

--- a/arm/ui/comments.json
+++ b/arm/ui/comments.json
@@ -13,7 +13,7 @@
     },
     "ARM_NAME": "# A friendly name for this machine. Useful if you are running multiple instances.\n# Used in notification titles.",
     "ARM_CHILDREN": "# Comma delimited list of child ARM servers to display on the Home Page\n# Should be full protocol, path, and port: http://192.168.0.100:8080/",
-    "PREVENT_99": "# Prevent ARM from wasting time on 99 Title protected DVDs.\n# A DRM scheme used on some DVDs which creates fake titles which confuses Handbrake.\n# When set to \"true\" affected DVDs will be autoejected on insertion.",
+    "PREVENT_99": "# Workaround for Track 99\n# A DRM scheme used on some DVDs which creates fake titles which confuses Handbrake.\n# When set to \"false\" affected DVDs will be passed to MakeMKV for ripping, but this can crash or hang\n# Setting this to true will eject the disc and log only to the system logging",
     "ARM_CHECK_UDF": "# Distinguish UDF video discs from UDF data discs.  Requires mounting disc so adds a few seconds to the identify script.",
     "GET_VIDEO_TITLE": "# When enabled if the disc is a DVD use dvdid to calculate a crc64 and query Windows Media Meta Services for the Movie Title.\n# For BluRays attempts to extract the title from an XML file on the disc",
     "ARM_API_KEY": "# ARM dvd crc64 api key\n# This is only needed if you would like to send movies to the database",

--- a/arm/ui/constants.py
+++ b/arm/ui/constants.py
@@ -1,4 +1,5 @@
-"""ARM UI Constants"""
+"""ARM Constants"""
+# UI
 HOME_PAGE = '/index'
 ERROR_PAGE = 'error.html'
 ERROR_REDIRECT = "/error"
@@ -6,3 +7,6 @@ SETUP_STAGE_2 = '/setup'
 NO_ADMIN_ACCOUNT = "No admin account found"
 NO_JOB = "No job supplied"
 JSON_TYPE = "application/json"
+# Ripper
+NOTIFY_TITLE = "ARM notification"
+PROCESS_COMPLETE = " processing complete. "

--- a/arm/ui/routes.py
+++ b/arm/ui/routes.py
@@ -230,9 +230,8 @@ def feed_json():
     is your call
     You can then add a function inside utils to deal with the request
     """
-    return_json = {}
     mode = str(request.args.get('mode'))
-
+    return_json = {'mode': mode, 'success': False}
     valid_data = {
         'j_id': request.args.get('job'),
         'searchq': request.args.get('q'),

--- a/arm/ui/routes.py
+++ b/arm/ui/routes.py
@@ -239,7 +239,8 @@ def feed_json():
         'logpath': cfg['LOGPATH'],
         'fail': 'fail',
         'success': 'success',
-        'joblist': 'joblist'
+        'joblist': 'joblist',
+        'mode': mode
     }
     valid_modes = {
         'delete': {'funct': json_api.delete_job, 'args': ('j_id', 'mode')},

--- a/arm/ui/routes.py
+++ b/arm/ui/routes.py
@@ -668,7 +668,7 @@ def import_movies():
 
     for movie in movie_dirs:
         # will match 'Movie (0000)'
-        regex = r"([\w\ \'\.\-\&\,]*?) \(([0-9]{2,4})\)"
+        regex = r"([\w\ \'\.\-\&\,]*?) \((\d{2,4})\)"
         # get our match
         matched = re.match(regex, movie)
         # if we can match the standard arm output format "Movie (year)"

--- a/arm/ui/static/js/database.js
+++ b/arm/ui/static/js/database.js
@@ -149,8 +149,9 @@ function switchFixPerms() {
  * In the event of a failed request warn the user and then hide the
  * messages after a timeout
  */
-function processFailedReturn() {
-    $("#message3").removeClass("d-none");
+function processFailedReturn(data) {
+    $("#errorMessage").remove();
+    $("#message3").removeClass("d-none").append(`<div id="errorMessage"><hr>Error: ${data.Error}</div>`);
     $("#message1").addClass("d-none");
     $("#message2").addClass("d-none");
     $(MODEL_ID).modal("toggle");
@@ -189,7 +190,7 @@ function proccessReturn(data) {
                 break;
         }
     } else {
-        processFailedReturn();
+        processFailedReturn(data);
     }
 }
 

--- a/arm/ui/static/js/jobRefresh.js
+++ b/arm/ui/static/js/jobRefresh.js
@@ -223,7 +223,6 @@ function checkActiveJobs(data, serverIndex) {
             }
         });
     });
-    return true;
 }
 
 /**

--- a/arm/ui/static/js/jobRefresh.js
+++ b/arm/ui/static/js/jobRefresh.js
@@ -223,6 +223,7 @@ function checkActiveJobs(data, serverIndex) {
             }
         });
     });
+    return true;
 }
 
 /**

--- a/docs/arm.yaml.sample
+++ b/docs/arm.yaml.sample
@@ -13,9 +13,10 @@ ARM_NAME: ""
 # Should be full protocol, path, and port: http://192.168.0.100:8080
 ARM_CHILDREN: ""
 
-# Prevent ARM from wasting time on 99 Title protected DVDs.
+# Workaround for Track 99
 # A DRM scheme used on some DVDs which creates fake titles which confuses Handbrake.
-# When set to "true" affected DVDs will be autoejected on insertion.
+# When set to "false" affected DVDs will be passed to MakeMKV for ripping, but this can crash or hang
+# Setting this to true will eject the disc and log only to the system logging
 PREVENT_99: true
 
 # Distinguish UDF video discs from UDF data discs.  Requires mounting disc so adds a few seconds to the identify script.

--- a/scripts/arm_wrapper.sh
+++ b/scripts/arm_wrapper.sh
@@ -1,7 +1,9 @@
-#!/bin/bash
+#!/bin/bash -i
+
+set -e
 
 DEVNAME=$1
-
+PROTECTION=""
 #######################################################################################
 # YAML Parser to read Config
 #
@@ -14,7 +16,7 @@ function parse_yaml {
    sed -ne "s|^\($s\):|\1|" \
         -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
         -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
-   awk -F$fs '{
+   awk -F"$fs" '{
       indent = length($1)/2;
       vname[indent] = $2;
       for (i in vname) {if (i > indent) {delete vname[i]}}
@@ -25,29 +27,30 @@ function parse_yaml {
    }'
 }
 
-eval $(parse_yaml /etc/arm/arm.yaml "CONFIG_")
+eval "$(parse_yaml /etc/arm/arm.yaml "CONFIG_")"
 
 #######################################################################################
 # Log Discovered Type and Start Rip
 #######################################################################################
-
-# ID_CDROM_MEDIA_BD = Bluray
+# ID_CDROM_MEDIA_BD = Blu-ray
 # ID_CDROM_MEDIA_CD = CD
 # ID_CDROM_MEDIA_DVD = DVD
 
 if [ "$ID_CDROM_MEDIA_DVD" == "1" ]; then
-	if [ "$CONFIG_PREVENT_99" != "false" ]; then
-		numtracks=$(lsdvd /dev/${DEVNAME} 2> /dev/null | sed 's/,/ /' | cut -d ' ' -f 2 | grep -E '[0-9]+' | sort -r | head -n 1)
-		if [ "$numtracks" == "99" ]; then
-			echo "[ARM] ${DEVNAME} has 99 Track Protection. Bailing out and ejecting." | logger -t ARM -s
-			eject ${DEVNAME}
-			exit
+  numtracks=$(lsdvd "/dev/${DEVNAME}" 2> /dev/null | sed 's/,/ /' | cut -d ' ' -f 2 | grep -E '[0-9]+' | sort -r | head -n 1)
+	if [ "$numtracks" == "99" ]; then
+	  if [ "$CONFIG_PREVENT_99" == "true" ]; then
+		  echo "[ARM] ${DEVNAME} has 99 Track Protection...Ripping 99 is disabled.. Ejecting disc." | logger -t ARM -s
+			eject "$DEVNAME"
+		else
+			echo "[ARM] ${DEVNAME} has 99 Track Protection...Trying workaround" | logger -t ARM -s
+			PROTECTION="-p 1"
 		fi
 	fi
 	echo "[ARM] Starting ARM for DVD on ${DEVNAME}" | logger -t ARM -s
 
 elif [ "$ID_CDROM_MEDIA_BD" == "1" ]; then
-	echo "[ARM] Starting ARM for Bluray on ${DEVNAME}" | logger -t ARM -s
+	echo "[ARM] Starting ARM for Blu-ray on ${DEVNAME}" | logger -t ARM -s
 
 elif [ "$ID_CDROM_MEDIA_CD" == "1" ]; then
 	echo "[ARM] Starting ARM for CD on ${DEVNAME}" | logger -t ARM -s
@@ -61,7 +64,7 @@ else
 
 fi
 
-/bin/su -l -c "echo /usr/bin/python3 /opt/arm/arm/ripper/main.py -d ${DEVNAME} | at now" -s /bin/bash arm
+/bin/su -l -c "echo /usr/bin/python3 /opt/arm/arm/ripper/main.py -d ${DEVNAME} ${PROTECTION} | at now" -s /bin/bash arm
 
 #######################################################################################
 # Check to see if the admin page is running, if not, start it


### PR DESCRIPTION
- Work around added for Track 99 protection (ARM will now rip them using MakeMKV)

- All the arm main.py sections, that relate to dvd/blu-ray moved to its own file.

- arm.ripper now uses the arm.ui.constants file

- jobs are now back(mostly) to using the saved config from the database

- job_dupe_check now only returns 1 value (True|False)

- Added error message to message div in `/database`

- More fstrings, comments, etc.
--------------
Needs more testing/work, only tested on Ubuntu 20.04 LTS