### PR TITLE
Fix failure to start when ${HOME}/config/.abcde.conf exists

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -42,8 +42,11 @@ fi
 if [[ ! -f "${HOME}/.abcde.conf" ]] ; then
   echo "creating example abcde config ${HOME}/.abcde.conf"
   cp /opt/arm/setup/.abcde.conf "${HOME}/.abcde.conf"
-  ln -sv "${HOME}/.abcde.conf" "${HOME}/config/.abcde.conf"
   chown "${USER}.${USER}" "${HOME}/.abcde.conf"
+
+  if [[ ! -e "${HOME}/config/.abcde.conf" ]]; then
+      ln -sv "${HOME}/.abcde.conf" "${HOME}/config/.abcde.conf"
+  fi
 fi
 echo "setting makemkv app-Key"
 if ! [[ -z "${MAKEMKV_APP_KEY}" ]] ; then


### PR DESCRIPTION
The ARM container fails to start if it has previously initialised config/.abcde.conf when the ln command fails.