### PR TITLE
Fix Main Feature always True after editing

### DIFF
--- a/arm/ui/routes.py
+++ b/arm/ui/routes.py
@@ -535,7 +535,8 @@ def changeparams():
         cfg["MINLENGTH"] = config.MINLENGTH = format(form.MINLENGTH.data)
         cfg["MAXLENGTH"] = config.MAXLENGTH = format(form.MAXLENGTH.data)
         cfg["RIPMETHOD"] = config.RIPMETHOD = format(form.RIPMETHOD.data)
-        cfg["MAINFEATURE"] = config.MAINFEATURE = bool(format(form.MAINFEATURE.data))  # must be 1 for True 0 for False
+        # BooleanField yields "True" or "False"
+        cfg["MAINFEATURE"] = config.MAINFEATURE = format(form.MAINFEATURE.data) == "True"
         app.logger.debug(f"main={config.MAINFEATURE}")
         job.disctype = format(form.DISCTYPE.data)
         db.session.commit()


### PR DESCRIPTION
Fixes: #172

I can see from logging that when unselected `form.MAINFEATURE.data` is `"False"`, which is not any of python's expected Falsey values.

I am not at all familiar with this framework so there may be a more robust way to fix this.

I haven't spelunked the origin of the 'must be 1 for True 0 for False' comment. Can this form be used in a different context which yields different results?

This change fixes it for me when running in the docker image.