### PR TITLE
Fix ARM ui tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,9 +76,11 @@ jobs:
     - name: Fix config files
       run: |
         cp setup/arm.yaml arm.yaml
-        sudo mkdir -p /etc/arm/config/
+        sudo mkdir -p /etc/arm/config/ /home/arm/db /home/arm /home/arm/config /home/arm/media /home/arm/music
         sudo cp setup/arm.yaml /etc/arm/config/arm.yaml
         sudo cp setup/apprise.yaml /etc/arm/config/apprise.yaml
         sudo cp setup/.abcde.conf /etc/arm/config/abcde.conf
+        sudo mkdir -p /opt/arm/arm
+        sudo cp -r arm/migrations /opt/arm/arm
     - name: Run A.R.M ui
       run: timeout 1 python ./arm/runui.py || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi


### PR DESCRIPTION
The current tests fail because arm cant find the folders in the correct place.
```
Traceback (most recent call last):
  File "/home/runner/work/automatic-ripping-machine/automatic-ripping-machine/./arm/runui.py", line 10, in <module>
    import arm.ui.routes  # noqa E402
  File "/home/runner/work/automatic-ripping-machine/automatic-ripping-machine/arm/../arm/ui/routes.py", line 26, in <module>
    ui_utils.check_db_version(cfg.arm_config['INSTALLPATH'], cfg.arm_config['DBFILE'])
  File "/home/runner/work/automatic-ripping-machine/automatic-ripping-machine/arm/../arm/ui/utils.py", line 71, in check_db_version
    script = ScriptDirectory.from_config(config)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/alembic/script/base.py", line [21](https://github.com/1337-server/automatic-ripping-machine/runs/7376985904?check_suite_focus=true#step:8:22)0, in from_config
    return ScriptDirectory(
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/alembic/script/base.py", line 95, in __init__
    raise util.CommandError(
alembic.util.exc.CommandError: Path doesn't exist: '/opt/arm/arm/migrations'.  Please use the 'init' command to create a new scripts folder.
```
This PR moves them so that the tests can complete without issue